### PR TITLE
Tabular primitive cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 d3m_datasets
-exline.egg-info/
+distil.egg-info/
 api/ta2ta3api.egg-info
 *__pycache__*
 third_party/*
@@ -12,4 +12,4 @@ seed_datasets_current
 outputs/*
 output/*
 test.db
-exline.log
+distil.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY server-requirements.txt .
 COPY api api
 RUN pip3 install -r server-requirements.txt
 
-# Out-of-band Exline requirements
+# Out-of-band Distil requirements
 RUN apt update && \
     apt-get install -y ffmpeg build-essential libcap-dev curl && \
     pip3 install --upgrade pip cython==0.29.3 python-prctl==1.7 && \

--- a/config.py
+++ b/config.py
@@ -14,7 +14,7 @@ OUTPUT_DIR = os.getenv("OUTPUT_DIR", "output")
 PORT = os.getenv("PORT", "45042")
 
 # Configurable filename for output logs
-LOG_FILENAME = os.getenv("LOG_FILENAME", "exline.log")
+LOG_FILENAME = os.getenv("LOG_FILENAME", "distil-auto-ml.log")
 
 # User agent to supply to TA3 Systems
 SERVER_USER_AGENT='qntfy_ta2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,19 @@
 version: "2"
 services:
-  exline:
+  distil:
     build: .
     ports:
       - 45042:45042
     volumes:
       - ./seed_datasets_current:/seed_datasets_current
-      - ./exline:/app/exline
+      - ./distil:/app/distil
       - ./server:/app/server
       - ./main.py:/app/main.py
       - ./config.py:/app/config.py
   dummy-ta3:
     image: new-dummy
-    command: ["/usr/bin/python3", "-m", "dummy_ta3.dummy_ta3", "-p", "/seed_datasets_current/49_facebook/TRAIN/problem_TRAIN/problemDoc.json", "-d", "/seed_datasets_current", "-e", "exline", "-t", "300"]
+    command: ["/usr/bin/python3", "-m", "dummy_ta3.dummy_ta3", "-p", "/seed_datasets_current/49_facebook/TRAIN/problem_TRAIN/problemDoc.json", "-d", "/seed_datasets_current", "-e", "distil", "-t", "300"]
     links:
-      - "exline"
+      - "distil"
     volumes:
       - ./seed_datasets_current:/seed_datasets_current

--- a/main.py
+++ b/main.py
@@ -112,7 +112,7 @@ def fit_task(logger, session, task):
 
 def exline_task(logger, session, task):
     try:
-        logger.info('Starting exline task ID {}'.format(task.id))
+        logger.info('Starting distil task ID {}'.format(task.id))
         task.started_at = datetime.datetime.utcnow()
 
         # load the problem supplied by the search request into a d3m Problem type

--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -6,19 +6,19 @@ from d3m.container import dataset
 from d3m import container, exceptions, runtime
 from d3m.metadata import base as metadata_base, pipeline, problem, pipeline_run
 
-from exline.modeling import metrics
+from distil.modeling import metrics
 from processing import router
 
 from processing.pipelines import (collaborative_filtering,
                                   clustering,
                                   graph_matching,
-                                  image,
+                                  #image,
                                   question_answer,
                                   tabular,
                                   text,
                                   timeseries,
                                   link_prediction,
-                                  audio,
+                                  #audio,
                                   vertex_nomination,
                                   community_detection)
 

--- a/processing/pipelines/audio.py
+++ b/processing/pipelines/audio.py
@@ -12,10 +12,10 @@ from d3m.metadata.base import ArgumentType
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-from exline.primitives.ensemble_forest import EnsembleForestPrimitive
-from exline.primitives.audio_transfer import AudioTransferPrimitive
+from distil.primitives.ensemble_forest import EnsembleForestPrimitive
+from distil.primitives.audio_transfer import AudioTransferPrimitive
 
-from exline.primitives.audio_loader import AudioDatasetLoaderPrimitive
+from distil.primitives.audio_loader import AudioDatasetLoaderPrimitive
 
 
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)

--- a/processing/pipelines/clustering.py
+++ b/processing/pipelines/clustering.py
@@ -9,18 +9,18 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.simple_imputer import SimpleImputerPrimitive
-from exline.primitives.categorical_imputer import CategoricalImputerPrimitive
-from exline.primitives.standard_scaler import StandardScalerPrimitive
-from exline.primitives.replace_singletons import ReplaceSingletonsPrimitive
-from exline.primitives.one_hot_encoder import OneHotEncoderPrimitive
-from exline.primitives.binary_encoder import BinaryEncoderPrimitive
-from exline.primitives.text_encoder import TextEncoderPrimitive
-from exline.primitives.enrich_dates import EnrichDatesPrimitive
-from exline.primitives.missing_indicator import MissingIndicatorPrimitive
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
-from exline.primitives.zero_column_remover import ZeroColumnRemoverPrimitive
-from exline.primitives.k_means import KMeansPrimitive
+from distil.primitives.simple_imputer import SimpleImputerPrimitive
+from distil.primitives.categorical_imputer import CategoricalImputerPrimitive
+from distil.primitives.standard_scaler import StandardScalerPrimitive
+from distil.primitives.replace_singletons import ReplaceSingletonsPrimitive
+from distil.primitives.one_hot_encoder import OneHotEncoderPrimitive
+from distil.primitives.binary_encoder import BinaryEncoderPrimitive
+from distil.primitives.text_encoder import TextEncoderPrimitive
+from distil.primitives.enrich_dates import EnrichDatesPrimitive
+from distil.primitives.missing_indicator import MissingIndicatorPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.zero_column_remover import ZeroColumnRemoverPrimitive
+from distil.primitives.k_means import KMeansPrimitive
 
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 from common_primitives.remove_columns import RemoveColumnsPrimitive

--- a/processing/pipelines/clustering.py
+++ b/processing/pipelines/clustering.py
@@ -26,8 +26,6 @@ from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 from common_primitives.remove_columns import RemoveColumnsPrimitive
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-from exline.preprocessing.utils import MISSING_VALUE_INDICATOR
-
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
 
 # CDB: Totally unoptimized.  Pipeline creation code could be simplified but has been left

--- a/processing/pipelines/collaborative_filtering.py
+++ b/processing/pipelines/collaborative_filtering.py
@@ -9,8 +9,8 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
-from exline.primitives.collaborative_filtering import CollaborativeFilteringPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.collaborative_filtering import CollaborativeFilteringPrimitive
 
 from common_primitives.denormalize import DenormalizePrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive

--- a/processing/pipelines/community_detection.py
+++ b/processing/pipelines/community_detection.py
@@ -17,8 +17,6 @@ from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-from exline.preprocessing.utils import MISSING_VALUE_INDICATOR
-
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
 
 
@@ -29,7 +27,7 @@ def create_pipeline(metric: str) -> Pipeline:
     vertex_nomination_pipeline = Pipeline(context=PipelineContext.TESTING)
     vertex_nomination_pipeline.add_input(name='inputs')
 
-    # step 0 - extract the graphs 
+    # step 0 - extract the graphs
     step = PrimitiveStep(primitive_description=ExlineSingleGraphLoaderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')

--- a/processing/pipelines/community_detection.py
+++ b/processing/pipelines/community_detection.py
@@ -9,10 +9,10 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.load_single_graph import ExlineSingleGraphLoaderPrimitive
-from exline.primitives.community_detection import ExlineCommunityDetectionPrimitive
+from distil.primitives.load_single_graph import DistilSingleGraphLoaderPrimitive
+from distil.primitives.community_detection import DistilCommunityDetectionPrimitive
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
@@ -28,14 +28,14 @@ def create_pipeline(metric: str) -> Pipeline:
     vertex_nomination_pipeline.add_input(name='inputs')
 
     # step 0 - extract the graphs
-    step = PrimitiveStep(primitive_description=ExlineSingleGraphLoaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_target')
     vertex_nomination_pipeline.add_step(step)
 
     # step 1 - nominate
-    step = PrimitiveStep(primitive_description=ExlineCommunityDetectionPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilCommunityDetectionPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_target')
     step.add_hyperparameter('metric', ArgumentType.VALUE, metric)

--- a/processing/pipelines/graph_matching.py
+++ b/processing/pipelines/graph_matching.py
@@ -17,8 +17,6 @@ from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-from exline.preprocessing.utils import MISSING_VALUE_INDICATOR
-
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
 
 
@@ -29,14 +27,14 @@ def create_pipeline(metric: str) -> Pipeline:
     graph_matching_pipeline = Pipeline(context=PipelineContext.TESTING)
     graph_matching_pipeline.add_input(name='inputs')
 
-    # step 0 - extract the graphs 
+    # step 0 - extract the graphs
     step = PrimitiveStep(primitive_description=ExlineGraphLoaderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_target')
     graph_matching_pipeline.add_step(step)
 
-    # step 1 - match the graphs that have been seeded 
+    # step 1 - match the graphs that have been seeded
     step = PrimitiveStep(primitive_description=ExlineSeededGraphMatchingPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_target')

--- a/processing/pipelines/graph_matching.py
+++ b/processing/pipelines/graph_matching.py
@@ -9,10 +9,10 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.load_graphs import ExlineGraphLoaderPrimitive
-from exline.primitives.seeded_graph_matcher import ExlineSeededGraphMatchingPrimitive
+from distil.primitives.load_graphs import DistilGraphLoaderPrimitive
+from distil.primitives.seeded_graph_matcher import DistilSeededGraphMatchingPrimitive
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
@@ -28,14 +28,14 @@ def create_pipeline(metric: str) -> Pipeline:
     graph_matching_pipeline.add_input(name='inputs')
 
     # step 0 - extract the graphs
-    step = PrimitiveStep(primitive_description=ExlineGraphLoaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilGraphLoaderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_target')
     graph_matching_pipeline.add_step(step)
 
     # step 1 - match the graphs that have been seeded
-    step = PrimitiveStep(primitive_description=ExlineSeededGraphMatchingPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilSeededGraphMatchingPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_target')
     step.add_hyperparameter('metric', ArgumentType.VALUE, metric)

--- a/processing/pipelines/image.py
+++ b/processing/pipelines/image.py
@@ -16,9 +16,9 @@ from common_primitives.construct_predictions import ConstructPredictionsPrimitiv
 from common_primitives.denormalize import DenormalizePrimitive
 from common_primitives.dataframe_image_reader import DataFrameImageReaderPrimitive
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
-from exline.primitives.ensemble_forest import EnsembleForestPrimitive
-from exline.primitives.image_transfer import ImageTransferPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.ensemble_forest import EnsembleForestPrimitive
+from distil.primitives.image_transfer import ImageTransferPrimitive
 
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
 

--- a/processing/pipelines/link_prediction.py
+++ b/processing/pipelines/link_prediction.py
@@ -17,8 +17,6 @@ from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-from exline.preprocessing.utils import MISSING_VALUE_INDICATOR
-
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
 
 
@@ -29,7 +27,7 @@ def create_pipeline(metric: str) -> Pipeline:
     vertex_nomination_pipeline = Pipeline(context=PipelineContext.TESTING)
     vertex_nomination_pipeline.add_input(name='inputs')
 
-    # step 0 - extract the graphs 
+    # step 0 - extract the graphs
     step = PrimitiveStep(primitive_description=ExlineSingleGraphLoaderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')

--- a/processing/pipelines/link_prediction.py
+++ b/processing/pipelines/link_prediction.py
@@ -9,10 +9,10 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.load_single_graph import ExlineSingleGraphLoaderPrimitive
-from exline.primitives.link_prediction import ExlineLinkPredictionPrimitive
+from distil.primitives.load_single_graph import DistilSingleGraphLoaderPrimitive
+from distil.primitives.link_prediction import DistilLinkPredictionPrimitive
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
@@ -28,14 +28,14 @@ def create_pipeline(metric: str) -> Pipeline:
     vertex_nomination_pipeline.add_input(name='inputs')
 
     # step 0 - extract the graphs
-    step = PrimitiveStep(primitive_description=ExlineSingleGraphLoaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_target')
     vertex_nomination_pipeline.add_step(step)
 
     # step 1 - nominate
-    step = PrimitiveStep(primitive_description=ExlineLinkPredictionPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilLinkPredictionPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_target')
     step.add_hyperparameter('metric', ArgumentType.VALUE, metric)

--- a/processing/pipelines/question_answer.py
+++ b/processing/pipelines/question_answer.py
@@ -9,8 +9,8 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
-from exline.primitives.bert_classification import BertClassificationPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.bert_classification import BertClassificationPrimitive
 
 from common_primitives.denormalize import DenormalizePrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive

--- a/processing/pipelines/tabular.py
+++ b/processing/pipelines/tabular.py
@@ -26,8 +26,6 @@ from common_primitives.column_parser import ColumnParserPrimitive
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 from common_primitives.extract_columns_semantic_types import ExtractColumnsBySemanticTypesPrimitive
 
-from exline.preprocessing.utils import MISSING_VALUE_INDICATOR
-
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
 
 # CDB: Totally unoptimized.  Pipeline creation code could be simplified but has been left

--- a/processing/pipelines/tabular.py
+++ b/processing/pipelines/tabular.py
@@ -102,7 +102,6 @@ def create_pipeline(metric: str,
     # Append categorical imputer.  Finds missing categorical values and replaces them with an imputed value.
     step = PrimitiveStep(primitive_description=CategoricalImputerPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-    #step.add_hyperparameter('strategy', ArgumentType.VALUE, 'constant')
     step.add_output('produce')
     tabular_pipeline.add_step(step)
     previous_step += 1
@@ -116,18 +115,22 @@ def create_pipeline(metric: str,
     previous_step += 1
 
     # Adds a one hot encoder for categoricals of low cardinality.
-    step = PrimitiveStep(primitive_description=OneHotEncoderPrimitive.metadata.query())
-    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-    step.add_output('produce')
-    step.add_hyperparameter('max_one_hot', ArgumentType.VALUE, max_one_hot)
-    tabular_pipeline.add_step(step)
-    previous_step += 1
+    if cat_mode == 'one_hot':
+        step = PrimitiveStep(primitive_description=OneHotEncoderPrimitive.metadata.query())
+        step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+        step.add_output('produce')
+        step.add_hyperparameter('max_one_hot', ArgumentType.VALUE, max_one_hot)
+        tabular_pipeline.add_step(step)
+        previous_step += 1
 
     # Adds a binary encoder for categoricals of high cardinality.
     step = PrimitiveStep(primitive_description=BinaryEncoderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_output('produce')
-    step.add_hyperparameter('min_binary', ArgumentType.VALUE, max_one_hot + 1)
+    if cat_mode == 'one_hot':
+        step.add_hyperparameter('min_binary', ArgumentType.VALUE, max_one_hot + 1)
+    else:
+        step.add_hyperparameter('min_binary', ArgumentType.VALUE, 0)
     tabular_pipeline.add_step(step)
     previous_step += 1
 

--- a/processing/pipelines/tabular.py
+++ b/processing/pipelines/tabular.py
@@ -9,13 +9,13 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.categorical_imputer import CategoricalImputerPrimitive
-from exline.primitives.ensemble_forest_v2 import EnsembleForestV2Primitive
-from exline.primitives.replace_singletons import ReplaceSingletonsPrimitive
-from exline.primitives.one_hot_encoder import OneHotEncoderPrimitive
-from exline.primitives.binary_encoder import BinaryEncoderPrimitive
-from exline.primitives.text_encoder import TextEncoderPrimitive
-from exline.primitives.enrich_dates import EnrichDatesPrimitive
+from distil.primitives.categorical_imputer import CategoricalImputerPrimitive
+from distil.primitives.ensemble_forest_v2 import EnsembleForestV2Primitive
+from distil.primitives.replace_singletons import ReplaceSingletonsPrimitive
+from distil.primitives.one_hot_encoder import OneHotEncoderPrimitive
+from distil.primitives.binary_encoder import BinaryEncoderPrimitive
+from distil.primitives.text_encoder import TextEncoderPrimitive
+from distil.primitives.enrich_dates import EnrichDatesPrimitive
 
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 from common_primitives.remove_columns import RemoveColumnsPrimitive

--- a/processing/pipelines/text.py
+++ b/processing/pipelines/text.py
@@ -23,8 +23,6 @@ from common_primitives.denormalize import DenormalizePrimitive
 from exline.primitives.text_reader import TextReaderPrimitive
 
 
-from exline.preprocessing.utils import MISSING_VALUE_INDICATOR
-
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
 
 # CDB: Totally unoptimized.  Pipeline creation code could be simplified but has been left

--- a/processing/pipelines/text.py
+++ b/processing/pipelines/text.py
@@ -10,17 +10,17 @@ from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
 
-from exline.primitives.text_classifier import TextClassifierPrimitive
+from distil.primitives.text_classifier import TextClassifierPrimitive
 
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
 
 from common_primitives.denormalize import DenormalizePrimitive
 
-from exline.primitives.text_reader import TextReaderPrimitive
+from distil.primitives.text_reader import TextReaderPrimitive
 
 
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)

--- a/processing/pipelines/timeseries.py
+++ b/processing/pipelines/timeseries.py
@@ -9,10 +9,10 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
-from exline.primitives.ragged_dataset_loader import RaggedDatasetLoaderPrimitive
-from exline.primitives.timeseries_reshaper import TimeSeriesReshaperPrimitive
-from exline.primitives.timeseries_neighbours import TimeSeriesNeighboursPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.ragged_dataset_loader import RaggedDatasetLoaderPrimitive
+from distil.primitives.timeseries_reshaper import TimeSeriesReshaperPrimitive
+from distil.primitives.timeseries_neighbours import TimeSeriesNeighboursPrimitive
 
 from common_primitives.denormalize import DenormalizePrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive

--- a/processing/pipelines/vertex_nomination.py
+++ b/processing/pipelines/vertex_nomination.py
@@ -17,8 +17,6 @@ from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-from exline.preprocessing.utils import MISSING_VALUE_INDICATOR
-
 PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
 
 
@@ -29,7 +27,7 @@ def create_pipeline(metric: str) -> Pipeline:
     vertex_nomination_pipeline = Pipeline(context=PipelineContext.TESTING)
     vertex_nomination_pipeline.add_input(name='inputs')
 
-    # step 0 - extract the graphs 
+    # step 0 - extract the graphs
     step = PrimitiveStep(primitive_description=ExlineSingleGraphLoaderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')

--- a/processing/pipelines/vertex_nomination.py
+++ b/processing/pipelines/vertex_nomination.py
@@ -9,10 +9,10 @@ from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
-from exline.primitives.load_single_graph import ExlineSingleGraphLoaderPrimitive
-from exline.primitives.vertex_nomination import ExlineVertexNominationPrimitive
+from distil.primitives.load_single_graph import DistilSingleGraphLoaderPrimitive
+from distil.primitives.vertex_nomination import DistilVertexNominationPrimitive
 
-from exline.primitives.simple_column_parser import SimpleColumnParserPrimitive
+from distil.primitives.simple_column_parser import SimpleColumnParserPrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
@@ -28,14 +28,14 @@ def create_pipeline(metric: str) -> Pipeline:
     vertex_nomination_pipeline.add_input(name='inputs')
 
     # step 0 - extract the graphs
-    step = PrimitiveStep(primitive_description=ExlineSingleGraphLoaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_target')
     vertex_nomination_pipeline.add_step(step)
 
     # step 1 - nominate
-    step = PrimitiveStep(primitive_description=ExlineVertexNominationPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilVertexNominationPrimitive.metadata.query())
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_target')
     step.add_hyperparameter('metric', ArgumentType.VALUE, metric)

--- a/processing/router.py
+++ b/processing/router.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 """
-    exline/router.py
+    distil/router.py
 """
 
 import sys
 import logging
 from copy import deepcopy
-from exline.modeling.metrics import classification_metrics, regression_metrics
+from distil.modeling.metrics import classification_metrics, regression_metrics
 from typing import Sequence, Tuple
 from d3m.metadata import problem as _problem
 

--- a/server/server.py
+++ b/server/server.py
@@ -70,8 +70,8 @@ class ServerServicer(core_pb2_grpc.CoreServicer):
     UNIMPLEMENTED_MSG = "Ah, ah, ah, you didn't say the magic word"
 
     def __init__(self):
-        self.logger = logging.getLogger('exline.server.ServerServicer')
-        self.logger.info('Initialized Exline ServerServicer')
+        self.logger = logging.getLogger('distil.server.ServerServicer')
+        self.logger.info('Initialized Distil ServerServicer')
         self.msg = Messaging()
 
     def SearchSolutions(self, request, context):

--- a/server/task_manager.py
+++ b/server/task_manager.py
@@ -22,7 +22,7 @@ from d3m.metadata import pipeline
 class TaskManager():
     def __init__(self):
         self.session = models.get_session(config.DB_LOCATION)
-        self.logger = logging.getLogger('exline.TaskManager')
+        self.logger = logging.getLogger('distil.TaskManager')
         self.logger.info('Initialized TaskManager')
         self.msg = Messaging()
         self.validator = RequestValidator()

--- a/server/validation.py
+++ b/server/validation.py
@@ -9,7 +9,7 @@ import logging
 class RequestValidator:
     def __init__(self):
         self.msg = Messaging()
-        self.logger = logging.getLogger('exline.TaskManager')
+        self.logger = logging.getLogger('distil.TaskManager')
 
     def _validate_solution_id_exists(self, solution_id, session, request):
         solution_id = str(solution_id)

--- a/test_scripts/run_score.sh
+++ b/test_scripts/run_score.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+PIPELINE_ID=$1
+DATASET=$2
+
+[ -z "$D3MINPUTDIR" ] && echo "Error - D3MINPUTDIR unset" && exit 1
+[ -z "$D3MOUTPUTDIR" ] && echo "Error - D3MOUTPUTDIR unset" && exit 1
+[ -z "$D3MINPUTDIR" ] && echo "Error - D3MSTATICDIR unset" && exit 1
+[ -z "$DATASET" ] && echo "Error - DATASET unset" && exit 1
+[ -z "$PIPELINE_ID" ] && echo "Error - PIPELINE_ID unset" && exit 1
+
+mkdir -p ${D3MOUTPUTDIR}/logs && \
+mkdir -p ${D3MOUTPUTDIR}/predictions && \
+mkdir -p ${D3MOUTPUTDIR}/pipeline_runs && \
+mkdir -p ${D3MOUTPUTDIR}/score
+
+cp ./scoring_pipeline.yml ${D3MOUTPUTDIR}
+
+python3 -m d3m.runtime \
+    --volumes "${D3MSTATICDIR}" \
+    --context TESTING \
+    fit-score \
+    -p ${D3MOUTPUTDIR}/pipelines_ranked/$PIPELINE_ID.json \
+    -r ${D3MINPUTDIR}/$DATASET/TRAIN/problem_TRAIN/problemDoc.json \
+    -i ${D3MINPUTDIR}/$DATASET/TRAIN/dataset_TRAIN/datasetDoc.json \
+    -t ${D3MINPUTDIR}/$DATASET/TEST/dataset_TEST/datasetDoc.json \
+    -o ${D3MOUTPUTDIR}/predictions/$PIPELINE_ID.csv \
+    -O ${D3MOUTPUTDIR}/pipeline_runs/$PIPELINE_ID.yaml \
+    -n ${D3MOUTPUTDIR}/scoring_pipeline.yml \
+    -a ${D3MINPUTDIR}/$DATASET/SCORE/dataset_TEST/datasetDoc.json \
+    -c ${D3MOUTPUTDIR}/score/$PIPELINE_ID.score.csv
+

--- a/test_scripts/run_search.sh
+++ b/test_scripts/run_search.sh
@@ -10,4 +10,4 @@ python3 -m dummy_ta3.dummy_ta3 \
     -p $D3MINPUTDIR/$DATASET/${DATASET}_problem/problemDoc.json \
     -d $D3MINPUTDIR \
     -e localhost \
-    -t 300
+    -t 600

--- a/test_scripts/run_search.sh
+++ b/test_scripts/run_search.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+DATASET=$1
+
+[ -z "$D3MINPUTDIR" ] && echo "Error - D3MINPUTDIR unset" && exit 1
+[ -z "$D3MOUTPUTDIR" ] && echo "Error - D3MOUTPUTDIR unset" && exit 1
+[ -z "$DATASET" ] && echo "Error - DATASET unset" && exit 1
+
+python3 -m dummy_ta3.dummy_ta3 \
+    -p $D3MINPUTDIR/$DATASET/${DATASET}_problem/problemDoc.json \
+    -d $D3MINPUTDIR \
+    -e localhost \
+    -t 300

--- a/test_scripts/scoring_pipeline.yml
+++ b/test_scripts/scoring_pipeline.yml
@@ -1,0 +1,36 @@
+id: f596cd77-25f8-4d4c-a350-bb30ab1e58f6
+schema: https://metadata.datadrivendiscovery.org/schemas/v0/pipeline.json
+source:
+  name: DMC
+created: "2018-07-27T18:04:43.650608Z"
+context: TESTING
+name: Scoring pipeline
+description: |
+  A general scoring pipeline.
+inputs:
+  - name: predictions
+  - name: score dataset
+outputs:
+  - name: scores
+    data: steps.0.produce
+steps:
+  # Step 0.
+  - type: PRIMITIVE
+    primitive:
+      id: 799802fb-2e11-4ab7-9c5e-dda09eb52a70
+      version: 0.3.0
+      python_path: d3m.primitives.evaluation.compute_scores.Common
+      name: Compute scores given the metrics to use
+    arguments:
+      inputs:
+        type: CONTAINER
+        data: inputs.0
+      score_dataset:
+        type: CONTAINER
+        data: inputs.1
+    outputs:
+      - id: produce
+    hyperparams:
+      add_normalized_scores:
+        type: VALUE
+        data: false

--- a/utils.py
+++ b/utils.py
@@ -12,9 +12,9 @@ def generate_id():
     _id = str(uuid.uuid4())
     return _id
 
-def setup_logging(logging_level, log_file='exline.log', system_version="UNSET"):
+def setup_logging(logging_level, log_file='distil.log', system_version="UNSET"):
     # Setup logger and handlers
-    logger = logging.getLogger('exline')
+    logger = logging.getLogger('distil')
     # Don't propagate to any other loggers to dedupe logging due to d3m package
     logger.propagate = False
 


### PR DESCRIPTION
1. Updates tabular pipeline to use SKLearn primitives where possible
2. Removes `exline` references and replaces them with `distil`

Requires uncharted-distil/distil-primitives#17