### PR TITLE
Adding  attribute to HelloResponse message

### DIFF
--- a/server/messages.py
+++ b/server/messages.py
@@ -111,7 +111,8 @@ class Messaging:
 
     def make_hello_response_message(self):
         return core_pb2.HelloResponse(
-            user_agent=config.SERVER_USER_AGENT)
+            user_agent=config.SERVER_USER_AGENT,
+            version=core_pb2.DESCRIPTOR.GetOptions().Extensions[core_pb2.protocol_version])
 
     def get_solution_id(self, message):
         return message.solution_id


### PR DESCRIPTION
The Harvard-UT-Dallas integration test fails with:
```
[2019-07-15 22:48:31,060] [tworavens-ta3-tests-v9lw2/tests] [0m[31m     AssertionError: expected { Object (userAgent, version, ...) } to have a property 'version' of '2019.2.27', but got ''[0m[90m
```
The version in that error message does not match the current `protocol_version` in the core.proto file. However, it's true that the HelloResponse message is supposed to contain the protocol_version, and we were not setting it previously.