### PR TITLE
Updates for Simple-TA3 test failures

### DIFF
--- a/models.py
+++ b/models.py
@@ -67,6 +67,7 @@ class Requests(Base):
         DateTime,
         default=datetime.datetime.utcnow)
     internal_score = Column(Float)
+    output_key = Column(String)
 
 class FitSolution(Base):
     __tablename__ = 'fit_solution'

--- a/server/messages.py
+++ b/server/messages.py
@@ -110,9 +110,13 @@ class Messaging:
         return score
 
     def make_hello_response_message(self):
-        return core_pb2.HelloResponse(
+        resp = core_pb2.HelloResponse(
             user_agent=config.SERVER_USER_AGENT,
             version=core_pb2.DESCRIPTOR.GetOptions().Extensions[core_pb2.protocol_version])
+        resp.allowed_value_types.append(value_pb2.RAW)
+        resp.allowed_value_types.append(value_pb2.DATASET_URI)
+        resp.allowed_value_types.append(value_pb2.CSV_URI)
+        return resp
 
     def get_solution_id(self, message):
         return message.solution_id

--- a/server/messages.py
+++ b/server/messages.py
@@ -5,7 +5,9 @@ import config
 
 from api import core_pb2, problem_pb2, value_pb2, pipeline_pb2, primitive_pb2, utils
 
+from d3m import index
 from d3m.metadata import pipeline
+
 
 class Messaging:
 
@@ -218,4 +220,14 @@ class Messaging:
 
     def get_rank(self, msg):
         return msg.rank
+    def make_list_primitives_response(self):
+        resp = core_pb2.ListPrimitivesResponse()
+        primitives = [ primitive_pb2.Primitive(
+            id=prim_data.metadata["id"],
+            version=prim_data.metadata["version"],
+            python_path=prim_data.metadata["python_path"],
+            name=prim_data.metadata["name"],
+            digest=prim_data.metadata["digest"]) for prim_data in index.get_loaded_primitives()]
+        resp.primitives.extend(primitives)
+        return resp
 

--- a/server/messages.py
+++ b/server/messages.py
@@ -131,9 +131,14 @@ class Messaging:
         return core_pb2.FitSolutionResponse(
             request_id=request_id)
 
-    def make_get_fit_solution_results_response(self, fitted_solution_id, progess_msg):
-        resp = core_pb2.GetFitSolutionResultsResponse(fitted_solution_id=fitted_solution_id,
-                                                      progress=progess_msg)
+    def make_get_fit_solution_results_response(self, preds_path, output_key, fit_solution_id, progress_msg):
+        # make a proper URI with file:// prefix
+        csv_uri = pathlib.Path(preds_path).absolute().as_uri()
+        val = value_pb2.Value(csv_uri=csv_uri)
+        resp = core_pb2.GetFitSolutionResultsResponse(
+            fitted_solution_id=fit_solution_id,
+            progress=progress_msg,
+            exposed_outputs={output_key: val})
         return resp
 
     def get_output_key(self, message):

--- a/server/server.py
+++ b/server/server.py
@@ -141,8 +141,8 @@ class ServerServicer(core_pb2_grpc.CoreServicer):
         context.abort(grpc.StatusCode.UNIMPLEMENTED, self.UNIMPLEMENTED_MSG)
 
     def ListPrimitives(self, request, context):
-        # TODO
-        context.abort(grpc.StatusCode.UNIMPLEMENTED, self.UNIMPLEMENTED_MSG)
+        self.logger.debug("ListPrimitives: {}".format(request))
+        return self.msg.make_list_primitives_response()
 
     def Hello(self, request, context):
         return self.msg.make_hello_response_message()

--- a/server/task_manager.py
+++ b/server/task_manager.py
@@ -253,6 +253,7 @@ class TaskManager():
             .first()
 
         request.fit_solution_id = fit_solution.id
+        request.output_key = task.output_key
         self.session.commit()
         return request_id
 
@@ -273,10 +274,12 @@ class TaskManager():
                       .first()
                 fit_solution_id = getattr(request, 'fit_solution_id', False)
                 task_complete = True if fit_solution_id else False
+                task_output_key = request.output_key
             # otherwise get the necessary info from the FIT task
             else:
                 task_complete = task.ended
                 fit_solution_id = task.fit_solution_id
+                task_output_key = task.output_key
                 self.session.refresh(task)
 
             # Ensure task is reloaded on next access
@@ -287,8 +290,11 @@ class TaskManager():
                 self.logger.debug("FIT task not complete, waiting")
                 yield False
             if task_complete:
+                preds_path = utils.make_preds_filename(task.fit_solution_id)
+                if not preds_path.exists() and not preds_path.is_file():
+                    raise FileNotFoundError("Predictions file {} doesn't exist".format(preds_path))
                 progress_msg = self.msg.make_progress_msg("COMPLETED")
-                yield self.msg.make_get_fit_solution_results_response(fit_solution_id, progress_msg)
+                yield self.msg.make_get_fit_solution_results_response(preds_path, task_output_key, fit_solution_id, progress_msg)
                 break
 
     def ProduceSolution(self, message):
@@ -323,7 +329,8 @@ class TaskManager():
         request_record = models.Requests(id=request_id,
                                          task_id=task.id,
                                          type="PRODUCE",
-                                         fit_solution_id=fitted_solution_id)
+                                         fit_solution_id=fitted_solution_id,
+                                         output_key=output_key)
         self.session.add(request_record)
         self.session.commit()
 


### PR DESCRIPTION
Simple-TA3 test failures:

 *  Hello
    * Failure: `required value type RAW is not supported`
    * Solution: Add `allowed_value_types` to HelloResponse
 * List Primitives
   * Failure: `{"code":12, "message": "Ah, ah, ah, you didn't say the magic word"}`
   * Solution: Implement ListPrimitives API.
* Run Pipeline
  * Failure: Not sure? The screenshot of the failure has the output scrolling off the screen, so we can't see the error message.
* Search Solutions
  * Failure: `no exposed output`
  * Solution: Add `exposed_outputs` to the GetFitSolutionResultsResponse
