### PR TITLE
Run fully specified pipelines as non-standard

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,11 +117,19 @@ def exline_task(logger, session, task):
             problem_d3m = None
             target_name = None
 
-        search_template = pipeline.Pipeline.from_json(task.pipeline) if task.pipeline else None
-        pipe, dataset = ex_pipeline.create(task.dataset_uri, problem_d3m, search_template)
-        fitted_pipeline, result = ex_pipeline.fit(pipe, problem_d3m, dataset)
+        search_template = pipeline.Pipeline.from_json(
+            task.pipeline) if task.pipeline else None
+        pipe, dataset = ex_pipeline.create(
+            task.dataset_uri, problem_d3m, search_template)
 
-        pipeline_json = fitted_pipeline.pipeline.to_json(nest_subpipelines=True)
+        # Check to see if this is a fully specified pipeline.  If so, we'll run it as a non-standard since
+        # it doesn't need to be serialized.
+        run_as_stanard = not ex_pipeline.is_fully_specified(search_template)
+        fitted_pipeline, result = ex_pipeline.fit(
+            pipe, problem_d3m, dataset, is_standard_pipeline=run_as_stanard)
+
+        pipeline_json = fitted_pipeline.pipeline.to_json(
+            nest_subpipelines=True)
         str_buf = io.StringIO()
         try:
             result.pipeline_run.to_yaml(str_buf)

--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -139,8 +139,8 @@ def fit(pipeline: pipeline.Pipeline, problem: problem.Problem, input_dataset: co
     volumes_dir = config.D3MSTATICDIR
 
     fitted_runtime, _, result = runtime.fit(pipeline, [input_dataset], problem_description=problem, hyperparams=hyperparams, random_seed=random_seed,
-        volumes_dir=volumes_dir, context=metadata_base.Context.TESTING, runtime_environment=pipeline_run.RuntimeEnvironment()
-    )
+                                            volumes_dir=volumes_dir, context=metadata_base.Context.TESTING, runtime_environment=pipeline_run.RuntimeEnvironment(),
+                                            is_standard_pipeline=is_standard_pipeline)
 
     if result.has_error():
         raise result.error
@@ -153,6 +153,11 @@ def produce(fitted_pipeline: runtime.Runtime, input_dataset: container.Dataset) 
     if result.has_error():
         raise result.error
     return predictions
+
+
+def is_fully_specified(prepend: pipeline.Pipeline) -> bool:
+    # if there's a pipeline and it doesn't have a placeholder then its fully specified
+    return prepend and not [True for s in prepend.steps if isinstance(s, PlaceholderStep)]
 
 
 def _prepend_pipeline(base: pipeline.Pipeline, prepend: pipeline.Pipeline) -> pipeline.Pipeline:

--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -133,7 +133,7 @@ def create(dataset_doc_path: str, problem: dict, prepend: pipeline.Pipeline=None
     return pipeline, train_dataset
 
 
-def fit(pipeline: pipeline.Pipeline, problem: problem.Problem, input_dataset: container.Dataset) -> Tuple[Optional[runtime.Runtime], Optional[runtime.Result]]:
+def fit(pipeline: pipeline.Pipeline, problem: problem.Problem, input_dataset: container.Dataset, is_standard_pipeline = True) -> Tuple[Optional[runtime.Runtime], Optional[runtime.Result]]:
     hyperparams = None
     random_seed = 0
     volumes_dir = config.D3MSTATICDIR


### PR DESCRIPTION
Anytime we run a fully specified pipeline we will run it as non-standard to allow greater flexibility.  Currently this will let us generate predictions + shap outputs for ensemble forest pipelines.