### PR TITLE
Adds support for multiple pipeline outputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,10 +42,9 @@ def produce_task(logger, session, task):
         fitted_pipeline = dats['pipeline']
         test_dataset = dataset.Dataset.load(task.dataset_uri)
         results = ex_pipeline.produce(fitted_pipeline, test_dataset)
-
-        preds_path = utils.make_preds_filename(task.fit_solution_id)
-        results.to_csv(preds_path, index=False)
-
+        for result_key, result_df in results.values.items():
+            preds_path = utils.make_preds_filename(task.fit_solution_id, result_key)
+            result_df.to_csv(preds_path, index=False)
         session.commit()
     except Exception as e:
         logger.warn('Exception running task ID {}: {}'.format(task.id, e), exc_info=True)

--- a/models.py
+++ b/models.py
@@ -103,7 +103,7 @@ class Tasks(Base):
     worker_id = Column(String)
     dataset_uri = Column(String)
     # Start -- PRODUCE specific --
-    output_key = Column(String)
+    output_keys = Column(String)
     # End -- PRODUCE specific --
     pipeline = Column(String)
     pipeline_run = Column(String)

--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -148,11 +148,11 @@ def fit(pipeline: pipeline.Pipeline, problem: problem.Problem, input_dataset: co
     return fitted_runtime, result
 
 
-def produce(fitted_pipeline: runtime.Runtime, input_dataset: container.Dataset) -> container.DataFrame:
-    predictions, result = runtime.produce(fitted_pipeline, [input_dataset])
+def produce(fitted_pipeline: runtime.Runtime, input_dataset: container.Dataset) -> runtime.Result:
+    _, result = runtime.produce(fitted_pipeline, [input_dataset])
     if result.has_error():
         raise result.error
-    return predictions
+    return result
 
 
 def is_fully_specified(prepend: pipeline.Pipeline) -> bool:

--- a/processing/scoring.py
+++ b/processing/scoring.py
@@ -19,10 +19,6 @@ from processing import pipeline
 
 import copy
 
-
-PipelineContext = dutils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
-
 class Scorer:
     def __init__(self, logger, task, score_config, dats):
         self.logger = logger
@@ -167,7 +163,13 @@ class Scorer:
         # produce predictions from the fitted model and extract to single col dataframe
         # with the d3mIndex as the index
         _in = copy.deepcopy(self.inputs)
-        result_df = pipeline.produce(self.fitted_pipeline, _in)
+        results = pipeline.produce(self.fitted_pipeline, _in)
+        # Not sure how to do this properly - we assume that we will use `outputs.0` for scoring, but it is
+        # possible that, in a non-standard pipeline, `outputs.0` could be the output from another step,
+        # and `outputs.1` contains the predictions.
+        if len(results.values) > 1:
+            self.logger.warning("Pipleine produced > 1 outputs. Scoring first output only.")
+        result_df = results.values['outputs.0']
         result_df = result_df.set_index(result_df['d3mIndex'])
         result_df.index = result_df.index.map(int)
 

--- a/server/messages.py
+++ b/server/messages.py
@@ -145,19 +145,19 @@ class Messaging:
                                                       progress=progess_msg)
         return resp
 
-    def get_output_key(self, message):
+    def get_output_keys(self, message):
         output_keys = message.expose_outputs
+        output_keys = list(message.expose_outputs)
         if len(output_keys) != 0:
-            output_key = output_keys[-1]
+            return output_keys
         else:
-            output_key = None
-        return output_key
+            return None
 
     def unpack_produce_solution_request(self, message):
         fitted_solution_id = self.get_fitted_solution_id(message)
         dataset_uri = self.get_dataset_uri(message)
-        expose_output_key = self.get_output_key(message)
-        return fitted_solution_id, dataset_uri, expose_output_key
+        expose_output_keys = self.get_output_keys(message)
+        return fitted_solution_id, dataset_uri, expose_output_keys
 
     def make_produce_solution_response(self, request_id):
         return core_pb2.ProduceSolutionResponse(request_id=request_id)
@@ -177,12 +177,10 @@ class Messaging:
             pipeline=pipeline_description)
         return msg
 
-    def make_get_produce_solution_results_response(self, preds_fn, output_key, progress_msg):
-        # make a proper URI with file:// prefix
-        csv_uri = pathlib.Path(preds_fn).absolute().as_uri()
-        val = value_pb2.Value(csv_uri=csv_uri)
+    def make_get_produce_solution_results_response(self, output_key_map, progress_msg):
+        pb_output_map = { output_id:value_pb2.Value(csv_uri=csv_uri) for (output_id, csv_uri) in output_key_map.items() }
         rsp = core_pb2.GetProduceSolutionResultsResponse(
-                exposed_outputs={output_key: val},
+                exposed_outputs=pb_output_map,
                 progress=progress_msg)
         return rsp
 

--- a/server/validation.py
+++ b/server/validation.py
@@ -97,14 +97,14 @@ class RequestValidator:
         return solution_id
 
     def validate_produce_solution_request(self, request):
-        fitted_solution_id, dataset_uri, output_key = self.msg.unpack_produce_solution_request(request)
+        fitted_solution_id, dataset_uri, output_keys = self.msg.unpack_produce_solution_request(request)
         if not fitted_solution_id:
             raise ValueError("Must pass a solution_id: {}".format(request))
         if not dataset_uri:
             raise ValueError("Must pass a dataset_uri {}".format(request))
-        if output_key is None:
+        if output_keys is None:
             raise ValueError("Must specify outputs {}".format(request))
-        return fitted_solution_id, dataset_uri, output_key
+        return fitted_solution_id, dataset_uri, output_keys
 
     def validate_get_search_solutions_results_request(self, request, session):
         search_id = str(self.msg.get_search_id(request))

--- a/utils.py
+++ b/utils.py
@@ -59,12 +59,12 @@ def make_job_fn(task_id):
     filepath = pathlib.Path(config.OUTPUT_DIR, filename)
     return filepath.resolve()
 
-def make_preds_filename(task_id):
+def make_preds_filename(task_id, output_key):
     """Return the absolute path to the predictions filename.
 
     None of that os.path.join garbage, just good sweet Path.absolute()
 
     Down with os.path.join. I have learned my lesson.
     """
-    path = pathlib.Path(config.OUTPUT_DIR, '{}.csv'.format(task_id)).resolve()
+    path = pathlib.Path(config.OUTPUT_DIR, f'{format(task_id)}_{output_key}.csv').resolve()
     return path


### PR DESCRIPTION
Adds support for multiple pipeline outputs.  This required:
1.  Updating our produce call handling to to return a `Result` object (containing a list of dataframes) instead of just taking the first dataframe stored in it.
1.  Serializing the list of output keys to JSON so that it could be stored in the DB (storing as a list would reuqire a new table)
1. Deserializing from JSON to the list of output keys when the produce results are being sent
1. Updating the predictions path filename layout to include both the  fitted pipeline ID and now the output key.
