### PR TITLE
Remove missing indicator due to issue with column append

### DIFF
--- a/processing/pipelines/tabular.py
+++ b/processing/pipelines/tabular.py
@@ -139,17 +139,20 @@ def create_pipeline(metric: str,
     tabular_pipeline.add_step(step)
     previous_step += 1
 
-    # Failing during eval - https://github.com/uncharted-distil/distil-auto-ml/issues/105
     # Adds SK learn missing value indicator (list encoder must be run first to prevent the above failure)
-    step = PrimitiveStep(primitive_description=SKMissingIndicator.SKMissingIndicator.metadata.query())
-    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-    step.add_output('produce')
-    step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, True)
-    step.add_hyperparameter('return_result', ArgumentType.VALUE, 'append')
-    step.add_hyperparameter('error_on_new', ArgumentType.VALUE, False)
-    step.add_hyperparameter('error_on_no_input', ArgumentType.VALUE, False)
-    tabular_pipeline.add_step(step)
-    previous_step += 1
+    # Currently disabled due to the fact that it will only append a missing indicator column on produce if there is
+    # missing data present.  This leads to issues when there is missing data in the fit set and not the produce set, as the
+    # training features don't match the produce features.
+    #
+    # step = PrimitiveStep(primitive_description=SKMissingIndicator.SKMissingIndicator.metadata.query())
+    # step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    # step.add_output('produce')
+    # step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, True)
+    # step.add_hyperparameter('return_result', ArgumentType.VALUE, 'append')
+    # step.add_hyperparameter('error_on_new', ArgumentType.VALUE, False)
+    # step.add_hyperparameter('error_on_no_input', ArgumentType.VALUE, False)
+    # tabular_pipeline.add_step(step)
+    # previous_step += 1
 
 
     # Adds SK learn simple imputer


### PR DESCRIPTION
Disables the SKMissingIndicator due to the fact that it will only append a missing indicator column on produce if there is missing data identified.  This leads to issues when there is data missing from the fit set and not the produce set, as the training features don't match the produce features, leading to errors in the ensemble forest.