### PR TITLE
Produce exposed outputs

### DIFF
--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -149,7 +149,7 @@ def fit(pipeline: pipeline.Pipeline, problem: problem.Problem, input_dataset: co
 
 
 def produce(fitted_pipeline: runtime.Runtime, input_dataset: container.Dataset) -> runtime.Result:
-    _, result = runtime.produce(fitted_pipeline, [input_dataset])
+    _, result = runtime.produce(fitted_pipeline, [input_dataset], expose_produced_outputs=True)
     if result.has_error():
         raise result.error
     return result

--- a/server/messages.py
+++ b/server/messages.py
@@ -18,8 +18,9 @@ class Messaging:
 
     def get_problem_type(self, msg):
         _type = msg.problem.problem.task_keywords
-        if _type is problem_pb2.TASK_KEYWORD_UNDEFINED:
+        if len(_type) == 0 or problem_pb2.TASK_KEYWORD_UNDEFINED in _type:
             return False
+
         # this seems to only be used for validation, not used in router.
         _type_str = problem_pb2.TaskKeyword.Name(_type[0]).upper()
         return _type_str


### PR DESCRIPTION
1. Updates the produce call to expose outputs.  This will return outputs from the pipeline, along with steps.  We filter those we serialize and return to TA3 to those requested in the produce message.
1. Fixes an issue encountered during testing where the new problem task keyword array wasn't being checked for empty, which occurs in the fully specified pipeline case.