### PR TITLE
Adds lazy loading of primitives

### DIFF
--- a/processing/pipelines/audio.py
+++ b/processing/pipelines/audio.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 
 from common_primitives.column_parser import ColumnParserPrimitive
@@ -16,11 +16,6 @@ from distil.primitives.ensemble_forest import EnsembleForestPrimitive
 from distil.primitives.audio_transfer import AudioTransferPrimitive
 from distil.primitives.audio_loader import AudioDatasetLoaderPrimitive
 
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
-# CDB: Totally unoptimized.  Pipeline creation code could be simplified but has been left
-# in a naively implemented state for readability for now.
-#
 # Overall implementation relies on passing the entire dataset through the pipeline, with the primitives
 # identifying columns to operate on based on type.  Alternative implementation (that better lines up with
 # D3M approach, but generates more complex pipelines) would be to extract sub-sets by semantic type using
@@ -29,17 +24,18 @@ PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1
 def create_pipeline(metric: str,
                     cat_mode: str = 'one_hot',
                     max_one_hot: int = 16,
-                    scale: bool = False) -> Pipeline:
+                    scale: bool = False,
+                    resolver: Optional[Resolver] = None) -> Pipeline:
     previous_step = 0
     input_val = 'steps.{}.produce'
 
     # create the basic pipeline
-    audio_pipeline = Pipeline(context=PipelineContext.TESTING)
+    audio_pipeline = Pipeline()
     audio_pipeline.add_input(name='inputs')
 
 
     # step 0
-    step = PrimitiveStep(primitive_description=AudioDatasetLoaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=AudioDatasetLoaderPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_collection')
@@ -47,7 +43,7 @@ def create_pipeline(metric: str,
     audio_pipeline.add_step(step)
 
      # step 1 - parse columns.
-    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_output('produce')
     semantic_types = ('http://schema.org/Boolean', 'http://schema.org/Integer', 'http://schema.org/Float',
@@ -56,7 +52,7 @@ def create_pipeline(metric: str,
     audio_pipeline.add_step(step)
 
     # step 2 - Extract targets
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
     step.add_output('produce')
     target_types = ('https://metadata.datadrivendiscovery.org/types/Target', 'https://metadata.datadrivendiscovery.org/types/TrueTarget')
@@ -64,13 +60,13 @@ def create_pipeline(metric: str,
     audio_pipeline.add_step(step)
 
     # step 3 - featurize
-    step = PrimitiveStep(primitive_description=AudioTransferPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=AudioTransferPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_collection')
     step.add_output('produce')
     audio_pipeline.add_step(step)
 
     # step 4 -- Generates a random forest ensemble model.
-    step = PrimitiveStep(primitive_description=EnsembleForestPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=EnsembleForestPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
     step.add_output('produce')
@@ -78,7 +74,7 @@ def create_pipeline(metric: str,
     audio_pipeline.add_step(step)
 
     # step 5 - convert predictions to expected format
-    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
     step.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
     step.add_output('produce')

--- a/processing/pipelines/collaborative_filtering.py
+++ b/processing/pipelines/collaborative_filtering.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -16,26 +16,23 @@ from common_primitives.column_parser import ColumnParserPrimitive
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 from common_primitives.extract_columns_semantic_types import ExtractColumnsBySemanticTypesPrimitive
 
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
-
-def create_pipeline(metric: str) -> Pipeline:
+def create_pipeline(metric: str, resolver: Optional[Resolver] = None) -> Pipeline:
     previous_step = 0
     input_val = 'steps.{}.produce'
 
     # create the basic pipeline
-    cf_pipeline = Pipeline(context=PipelineContext.TESTING)
+    cf_pipeline = Pipeline()
     cf_pipeline.add_input(name='inputs')
 
    # extract dataframe from dataset
-    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     cf_pipeline.add_step(step)
     previous_step = 0
 
     # Parse columns.
-    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_output('produce')
     semantic_types = ('http://schema.org/Boolean', 'http://schema.org/Integer', 'http://schema.org/Float',
@@ -46,7 +43,7 @@ def create_pipeline(metric: str) -> Pipeline:
     parse_step = previous_step
 
     # Extract attributes
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
     step.add_output('produce')
     step.add_hyperparameter('semantic_types', ArgumentType.VALUE, ('https://metadata.datadrivendiscovery.org/types/Attribute',))
@@ -55,7 +52,7 @@ def create_pipeline(metric: str) -> Pipeline:
     attributes_step = previous_step
 
     # Extract targets
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
     step.add_output('produce')
     target_types = ('https://metadata.datadrivendiscovery.org/types/Target', 'https://metadata.datadrivendiscovery.org/types/TrueTarget')
@@ -65,7 +62,7 @@ def create_pipeline(metric: str) -> Pipeline:
     target_step = previous_step
 
     # Generates collaborative filtering model.
-    step = PrimitiveStep(primitive_description=CollaborativeFilteringPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=CollaborativeFilteringPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(attributes_step))
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(target_step))
     step.add_output('produce')
@@ -73,7 +70,7 @@ def create_pipeline(metric: str) -> Pipeline:
     previous_step += 1
 
     # convert predictions to expected format
-    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
     step.add_output('produce')

--- a/processing/pipelines/community_detection.py
+++ b/processing/pipelines/community_detection.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -15,25 +15,21 @@ from distil.primitives.community_detection import DistilCommunityDetectionPrimit
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
-
-
-def create_pipeline(metric: str) -> Pipeline:
+def create_pipeline(metric: str, resolver: Optional[Resolver] = None) -> Pipeline:
 
     # create the basic pipeline
-    vertex_nomination_pipeline = Pipeline(context=PipelineContext.TESTING)
+    vertex_nomination_pipeline = Pipeline()
     vertex_nomination_pipeline.add_input(name='inputs')
 
     # step 0 - extract the graphs
-    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_target')
     vertex_nomination_pipeline.add_step(step)
 
     # step 1 - nominate
-    step = PrimitiveStep(primitive_description=DistilCommunityDetectionPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilCommunityDetectionPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_target')
     step.add_hyperparameter('metric', ArgumentType.VALUE, metric)

--- a/processing/pipelines/data_augmentation_tabular.py
+++ b/processing/pipelines/data_augmentation_tabular.py
@@ -1,330 +1,331 @@
-# import os
-# import sys
-# from typing import List, Dict, Any, Tuple, Set, Optional
-# import logging
-# import numpy as np
-# import pandas as pd
+import os
+import sys
+from typing import List, Dict, Any, Tuple, Set, Optional
+import logging
+import numpy as np
+import pandas as pd
 
-# import json
-# import requests
+import json
+import requests
 
-# import config
+import config
 
-# from d3m import container, utils
-# from d3m.base import utils as base_utils
-# from d3m.metadata.pipeline import Pipeline, PrimitiveStep
-# from d3m.metadata.base import ArgumentType
-# from d3m.metadata import hyperparams
+from d3m import container, utils
+from d3m.base import utils as base_utils
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
+from d3m.metadata.base import ArgumentType
+from d3m.metadata import hyperparams
 
-# import datamart
-# import datamart_nyu
+import datamart
+import datamart_nyu
 
-# from distil.primitives.categorical_imputer import CategoricalImputerPrimitive
-# from distil.primitives.ensemble_forest import EnsembleForestPrimitive
-# from distil.primitives.replace_singletons import ReplaceSingletonsPrimitive
-# from distil.primitives.one_hot_encoder import OneHotEncoderPrimitive
-# from distil.primitives.binary_encoder import BinaryEncoderPrimitive
-# from distil.primitives.text_encoder import TextEncoderPrimitive
-# from distil.primitives.enrich_dates import EnrichDatesPrimitive
+from distil.primitives.categorical_imputer import CategoricalImputerPrimitive
+from distil.primitives.ensemble_forest import EnsembleForestPrimitive
+from distil.primitives.replace_singletons import ReplaceSingletonsPrimitive
+from distil.primitives.one_hot_encoder import OneHotEncoderPrimitive
+from distil.primitives.binary_encoder import BinaryEncoderPrimitive
+from distil.primitives.text_encoder import TextEncoderPrimitive
+from distil.primitives.enrich_dates import EnrichDatesPrimitive
 
-# from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
-# from common_primitives.remove_columns import RemoveColumnsPrimitive
-# from common_primitives.column_parser import ColumnParserPrimitive
-# from common_primitives.construct_predictions import ConstructPredictionsPrimitive
-# from common_primitives.extract_columns_semantic_types import ExtractColumnsBySemanticTypesPrimitive
-# from common_primitives.dataset_sample import DatasetSamplePrimitive
-# from common_primitives.denormalize import DenormalizePrimitive
-# from common_primitives.replace_semantic_types import ReplaceSemanticTypesPrimitive
-# from common_primitives.datamart_download import DataMartDownloadPrimitive
-# from common_primitives.datamart_augment import DataMartAugmentPrimitive
-# from common_primitives.extract_columns_structural_types import ExtractColumnsByStructuralTypesPrimitive
+from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
+from common_primitives.remove_columns import RemoveColumnsPrimitive
+from common_primitives.column_parser import ColumnParserPrimitive
+from common_primitives.construct_predictions import ConstructPredictionsPrimitive
+from common_primitives.extract_columns_semantic_types import ExtractColumnsBySemanticTypesPrimitive
+from common_primitives.dataset_sample import DatasetSamplePrimitive
+from common_primitives.denormalize import DenormalizePrimitive
+from common_primitives.replace_semantic_types import ReplaceSemanticTypesPrimitive
+from common_primitives.datamart_download import DataMartDownloadPrimitive
+from common_primitives.datamart_augment import DataMartAugmentPrimitive
+from common_primitives.extract_columns_structural_types import ExtractColumnsByStructuralTypesPrimitive
 
-# from d3m.primitives.data_cleaning.column_type_profiler import Simon
+from d3m.primitives.data_cleaning.column_type_profiler import Simon
 
-# from sklearn_wrap import SKMissingIndicator
-# from sklearn_wrap import SKImputer
-# from sklearn_wrap import SKStandardScaler
-# from sklearn_wrap import SKPCA
+from sklearn_wrap import SKMissingIndicator
+from sklearn_wrap import SKImputer
+from sklearn_wrap import SKStandardScaler
+from sklearn_wrap import SKPCA
 
-# logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
-# def create_pipeline(metric: str,
-#                     keywords: list = [],
-#                     dataset: container.Dataset = None,
-#                     include_aug = True) -> Pipeline:
+def create_pipeline(metric: str,
+                    keywords: list = [],
+                    dataset: container.Dataset = None,
+                    include_aug = True,
+                    resolver: Optional[Resolver] = None) -> Pipeline:
 
-#     max_one_hot: int = 16
-#     max_rows = config.AUG_MAX_ROWS
-#     max_cols = config.AUG_MAX_COLS
+    max_one_hot: int = 16
+    max_rows = config.AUG_MAX_ROWS
+    max_cols = config.AUG_MAX_COLS
 
-#     input_val = 'steps.{}.produce'
+    input_val = 'steps.{}.produce'
 
-#     # create the basic pipeline
-#     tabular_pipeline = Pipeline()
-#     tabular_pipeline.add_input(name='inputs')
-#     previous_step = 0
+    # create the basic pipeline
+    tabular_pipeline = Pipeline()
+    tabular_pipeline.add_input(name='inputs')
+    previous_step = 0
 
-#     # get the dataset shape
-#     _, df = base_utils.get_tabular_resource(dataset, None)
-#     df_rows = df.shape[0]
-#     df_cols = df.shape[1]
+    # get the dataset shape
+    _, df = base_utils.get_tabular_resource(dataset, None)
+    df_rows = df.shape[0]
+    df_cols = df.shape[1]
 
-#     # check join if requested
-#     join_result: datamart.DatamartSearchResult = None
-#     if include_aug:
-#        join_result, df_cols, df_rows = _query_datamart(keywords, dataset)
-#     include_aug = join_result != None
+    # check join if requested
+    join_result: datamart.DatamartSearchResult = None
+    if include_aug:
+       join_result, df_cols, df_rows = _query_datamart(keywords, dataset)
+    include_aug = join_result != None
 
-#     if include_aug:
-#         # Augment dataset - currently just picks the first query result
-#         step = PrimitiveStep(primitive_description=DataMartAugmentPrimitive.metadata.query())
-#         step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
-#         step.add_output('produce')
-#         step.add_hyperparameter('system_identifier', ArgumentType.VALUE, "NYU")
-#         step.add_hyperparameter('search_result', ArgumentType.VALUE, join_result.serialize())
-#         tabular_pipeline.add_step(step)
-#     else:
-#         logger.warn("Datamart did not return result for input dataset - proceeding with baseline dataset")
+    if include_aug:
+        # Augment dataset - currently just picks the first query result
+        step = PrimitiveStep(primitive_description=DataMartAugmentPrimitive.metadata.query(), resolver=resolver)
+        step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
+        step.add_output('produce')
+        step.add_hyperparameter('system_identifier', ArgumentType.VALUE, "NYU")
+        step.add_hyperparameter('search_result', ArgumentType.VALUE, join_result.serialize())
+        tabular_pipeline.add_step(step)
+    else:
+        logger.warn("Datamart did not return result for input dataset - proceeding with baseline dataset")
 
-#     # Denormalize
-#     data_ref = ""
-#     if include_aug:
-#         data_ref = input_val.format(previous_step)
-#         previous_step += 1
-#     else:
-#         data_ref = 'inputs.0'
-#     step = PrimitiveStep(primitive_description=DenormalizePrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=data_ref)
-#     step.add_output('produce')
-#     tabular_pipeline.add_step(step)
+    # Denormalize
+    data_ref = ""
+    if include_aug:
+        data_ref = input_val.format(previous_step)
+        previous_step += 1
+    else:
+        data_ref = 'inputs.0'
+    step = PrimitiveStep(primitive_description=DenormalizePrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=data_ref)
+    step.add_output('produce')
+    tabular_pipeline.add_step(step)
 
-#      # if join rows is greater than max rows, sample
-#     if df_rows > max_rows:
-#         step = PrimitiveStep(primitive_description=DatasetSamplePrimitive.metadata.query())
-#         step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#         step.add_output('produce')
-#         step.add_hyperparameter('sample_size', ArgumentType.VALUE, max_rows)
-#         tabular_pipeline.add_step(step)
-#         previous_step += 1
+     # if join rows is greater than max rows, sample
+    if df_rows > max_rows:
+        step = PrimitiveStep(primitive_description=DatasetSamplePrimitive.metadata.query(), resolver=resolver)
+        step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+        step.add_output('produce')
+        step.add_hyperparameter('sample_size', ArgumentType.VALUE, max_rows)
+        tabular_pipeline.add_step(step)
+        previous_step += 1
 
-#     # extract dataframe from dataset
-#     step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # extract dataframe from dataset
+    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # profile columns since datamart profiling can lead to errors
-#     # step = PrimitiveStep(primitive_description=SimpleProfilerPrimitive.metadata.query())
-#     # step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     # step.add_output('produce')
-#     # tabular_pipeline.add_step(step)
-#     # previous_step += 1
+    # profile columns since datamart profiling can lead to errors
+    # step = PrimitiveStep(primitive_description=SimpleProfilerPrimitive.metadata.query(), resolver=resolver)
+    # step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    # step.add_output('produce')
+    # tabular_pipeline.add_step(step)
+    # previous_step += 1
 
-#     step = PrimitiveStep(primitive_description=Simon.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     step.add_hyperparameter('overwrite', ArgumentType.VALUE, True)
-#     step.add_hyperparameter('statistical_classification', ArgumentType.VALUE, True)
-#     step.add_hyperparameter('multi_label_classification', ArgumentType.VALUE, False)
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    step = PrimitiveStep(primitive_description=Simon.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    step.add_hyperparameter('overwrite', ArgumentType.VALUE, True)
+    step.add_hyperparameter('statistical_classification', ArgumentType.VALUE, True)
+    step.add_hyperparameter('multi_label_classification', ArgumentType.VALUE, False)
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # replace text fields with categorical - work around for text encoder failing on empty strings
-#     step = PrimitiveStep(primitive_description=ReplaceSemanticTypesPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     from_types = ('http://schema.org/Text',)
-#     to_types = ('https://metadata.datadrivendiscovery.org/types/CategoricalData',)
-#     step.add_hyperparameter('from_semantic_types', ArgumentType.VALUE, from_types)
-#     step.add_hyperparameter('to_semantic_types', ArgumentType.VALUE, to_types)
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # replace text fields with categorical - work around for text encoder failing on empty strings
+    step = PrimitiveStep(primitive_description=ReplaceSemanticTypesPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    from_types = ('http://schema.org/Text',)
+    to_types = ('https://metadata.datadrivendiscovery.org/types/CategoricalData',)
+    step.add_hyperparameter('from_semantic_types', ArgumentType.VALUE, from_types)
+    step.add_hyperparameter('to_semantic_types', ArgumentType.VALUE, to_types)
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # replace int fields with float - workaround for column parser failing when a column with semantic type of int contains
-#     # a floating point value
-#     # step = PrimitiveStep(primitive_description=ReplaceSemanticTypesPrimitive.metadata.query())
-#     # step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     # step.add_output('produce')
-#     # from_types = ('http://schema.org/Integer',)
-#     # to_types = ('https://schema.org/Float',)
-#     # step.add_hyperparameter('from_semantic_types', ArgumentType.VALUE, from_types)
-#     # step.add_hyperparameter('to_semantic_types', ArgumentType.VALUE, to_types)
-#     # tabular_pipeline.add_step(step)
-#     # previous_step += 1
+    # replace int fields with float - workaround for column parser failing when a column with semantic type of int contains
+    # a floating point value
+    # step = PrimitiveStep(primitive_description=ReplaceSemanticTypesPrimitive.metadata.query(), resolver=resolver)
+    # step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    # step.add_output('produce')
+    # from_types = ('http://schema.org/Integer',)
+    # to_types = ('https://schema.org/Float',)
+    # step.add_hyperparameter('from_semantic_types', ArgumentType.VALUE, from_types)
+    # step.add_hyperparameter('to_semantic_types', ArgumentType.VALUE, to_types)
+    # tabular_pipeline.add_step(step)
+    # previous_step += 1
 
-#     # Parse columns.
-#     step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     semantic_types = ('http://schema.org/Boolean', 'http://schema.org/Integer', 'http://schema.org/Float',
-#                       'https://metadata.datadrivendiscovery.org/types/FloatVector')
-#     step.add_hyperparameter('parse_semantic_types', ArgumentType.VALUE, semantic_types)
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
-#     parse_step = previous_step
+    # Parse columns.
+    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    semantic_types = ('http://schema.org/Boolean', 'http://schema.org/Integer', 'http://schema.org/Float',
+                      'https://metadata.datadrivendiscovery.org/types/FloatVector')
+    step.add_hyperparameter('parse_semantic_types', ArgumentType.VALUE, semantic_types)
+    tabular_pipeline.add_step(step)
+    previous_step += 1
+    parse_step = previous_step
 
-#     # Extract attributes
-#     step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
-#     step.add_output('produce')
-#     step.add_hyperparameter('semantic_types', ArgumentType.VALUE, ('https://metadata.datadrivendiscovery.org/types/Attribute',))
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
-#     attributes_step = previous_step
+    # Extract attributes
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
+    step.add_output('produce')
+    step.add_hyperparameter('semantic_types', ArgumentType.VALUE, ('https://metadata.datadrivendiscovery.org/types/Attribute',))
+    tabular_pipeline.add_step(step)
+    previous_step += 1
+    attributes_step = previous_step
 
-#     # Extract targets
-#     step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
-#     step.add_output('produce')
-#     target_types = ('https://metadata.datadrivendiscovery.org/types/Target', 'https://metadata.datadrivendiscovery.org/types/TrueTarget')
-#     step.add_hyperparameter('semantic_types', ArgumentType.VALUE, target_types)
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
-#     target_step = previous_step
+    # Extract targets
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
+    step.add_output('produce')
+    target_types = ('https://metadata.datadrivendiscovery.org/types/Target', 'https://metadata.datadrivendiscovery.org/types/TrueTarget')
+    step.add_hyperparameter('semantic_types', ArgumentType.VALUE, target_types)
+    tabular_pipeline.add_step(step)
+    previous_step += 1
+    target_step = previous_step
 
-#     # Append date enricher.  Looks for date columns and normalizes them.
-#     step = PrimitiveStep(primitive_description=EnrichDatesPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(attributes_step))
-#     step.add_output('produce')
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # Append date enricher.  Looks for date columns and normalizes them.
+    step = PrimitiveStep(primitive_description=EnrichDatesPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(attributes_step))
+    step.add_output('produce')
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # Append singleton replacer.  Looks for categorical values that only occur once in a column and replace them with a flag.
-#     step = PrimitiveStep(primitive_description=ReplaceSingletonsPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # Append singleton replacer.  Looks for categorical values that only occur once in a column and replace them with a flag.
+    step = PrimitiveStep(primitive_description=ReplaceSingletonsPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # Adds a one hot encoder for categoricals of low cardinality.
-#     step = PrimitiveStep(primitive_description=OneHotEncoderPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     step.add_hyperparameter('max_one_hot', ArgumentType.VALUE, max_one_hot)
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # Adds a one hot encoder for categoricals of low cardinality.
+    step = PrimitiveStep(primitive_description=OneHotEncoderPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    step.add_hyperparameter('max_one_hot', ArgumentType.VALUE, max_one_hot)
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # Adds a binary encoder for categoricals of high cardinality.
-#     step = PrimitiveStep(primitive_description=BinaryEncoderPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     step.add_hyperparameter('min_binary', ArgumentType.VALUE, max_one_hot)
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # Adds a binary encoder for categoricals of high cardinality.
+    step = PrimitiveStep(primitive_description=BinaryEncoderPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    step.add_hyperparameter('min_binary', ArgumentType.VALUE, max_one_hot)
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # There shouldn't be any strings by this point, but if something has been mistyped in metadata it could still be
-#     # hanging around.  We'll pull it out now.
-#     step = PrimitiveStep(primitive_description=ExtractColumnsByStructuralTypesPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     step.add_hyperparameter('negate', ArgumentType.VALUE, True)
-#     step.add_hyperparameter('structural_types', ArgumentType.VALUE, (str,))
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # There shouldn't be any strings by this point, but if something has been mistyped in metadata it could still be
+    # hanging around.  We'll pull it out now.
+    step = PrimitiveStep(primitive_description=ExtractColumnsByStructuralTypesPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    step.add_hyperparameter('negate', ArgumentType.VALUE, True)
+    step.add_hyperparameter('structural_types', ArgumentType.VALUE, (str,))
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # Adds SK learn missing value indicator
-#     step = PrimitiveStep(primitive_description=SKMissingIndicator.SKMissingIndicator.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, False)
-#     step.add_hyperparameter('return_result', ArgumentType.VALUE, 'append')
-#     step.add_hyperparameter('error_on_new', ArgumentType.VALUE, False)
-#     step.add_hyperparameter('error_on_no_input', ArgumentType.VALUE, False)
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # Adds SK learn missing value indicator
+    step = PrimitiveStep(primitive_description=SKMissingIndicator.SKMissingIndicator.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, False)
+    step.add_hyperparameter('return_result', ArgumentType.VALUE, 'append')
+    step.add_hyperparameter('error_on_new', ArgumentType.VALUE, False)
+    step.add_hyperparameter('error_on_no_input', ArgumentType.VALUE, False)
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # Adds SK learn simple imputer
-#     step = PrimitiveStep(primitive_description=SKImputer.SKImputer.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_output('produce')
-#     step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, True)
-#     step.add_hyperparameter('error_on_no_input', ArgumentType.VALUE, False)
-#     step.add_hyperparameter('return_result', ArgumentType.VALUE, 'replace')
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # Adds SK learn simple imputer
+    step = PrimitiveStep(primitive_description=SKImputer.SKImputer.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_output('produce')
+    step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, True)
+    step.add_hyperparameter('error_on_no_input', ArgumentType.VALUE, False)
+    step.add_hyperparameter('return_result', ArgumentType.VALUE, 'replace')
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # PCA step
-#     if df_cols > max_cols:
-#         step = PrimitiveStep(primitive_description=SKPCA.SKPCA.metadata.query())
-#         step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#         step.add_output('produce')
-#         step.add_hyperparameter('n_components', ArgumentType.VALUE, max_cols)
-#         step.add_hyperparameter('error_on_no_input', ArgumentType.VALUE, False)
-#         tabular_pipeline.add_step(step)
-#         previous_step += 1
+    # PCA step
+    if df_cols > max_cols:
+        step = PrimitiveStep(primitive_description=SKPCA.SKPCA.metadata.query(), resolver=resolver)
+        step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+        step.add_output('produce')
+        step.add_hyperparameter('n_components', ArgumentType.VALUE, max_cols)
+        step.add_hyperparameter('error_on_no_input', ArgumentType.VALUE, False)
+        tabular_pipeline.add_step(step)
+        previous_step += 1
 
-#     # Generates a random forest ensemble model.
-#     step = PrimitiveStep(primitive_description=EnsembleForestPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(target_step))
-#     step.add_output('produce')
-#     step.add_hyperparameter('metric', ArgumentType.VALUE, metric)
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # Generates a random forest ensemble model.
+    step = PrimitiveStep(primitive_description=EnsembleForestPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(target_step))
+    step.add_output('produce')
+    step.add_hyperparameter('metric', ArgumentType.VALUE, metric)
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # # convert predictions to expected format
-#     step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
-#     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-#     step.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
-#     step.add_output('produce')
-#     tabular_pipeline.add_step(step)
-#     previous_step += 1
+    # # convert predictions to expected format
+    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query(), resolver=resolver)
+    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
+    step.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
+    step.add_output('produce')
+    tabular_pipeline.add_step(step)
+    previous_step += 1
 
-#     # Adding output step to the pipeline
-#     tabular_pipeline.add_output(name='output', data_reference=input_val.format(previous_step))
+    # Adding output step to the pipeline
+    tabular_pipeline.add_output(name='output', data_reference=input_val.format(previous_step))
 
-#     return tabular_pipeline
+    return tabular_pipeline
 
-# def _query_datamart(keywords: List[Any], dataset: Optional[container.Dataset]) -> Tuple[datamart.DatamartSearchResult, int, int]:
-#      # Search NYU DataMart using dataset and keyword
-#     URL = os.environ['DATAMART_URL_NYU']
-#     client = datamart_nyu.RESTDatamart(URL)
+def _query_datamart(keywords: List[Any], dataset: Optional[container.Dataset]) -> Tuple[datamart.DatamartSearchResult, int, int]:
+     # Search NYU DataMart using dataset and keyword
+    URL = os.environ['DATAMART_URL_NYU']
+    client = datamart_nyu.RESTDatamart(URL)
 
-#     # extract the keywords from the data aug info
-#     keywords_list: Set[str] = set()
-#     for keywords_entry in keywords:
-#         keywords_list.update(keywords_entry['keywords'])
+    # extract the keywords from the data aug info
+    keywords_list: Set[str] = set()
+    for keywords_entry in keywords:
+        keywords_list.update(keywords_entry['keywords'])
 
-#     query = datamart.DatamartQuery(
-#         keywords = list(keywords_list),
-#         variables = []
-#     )
-#     cursor = client.search_with_data(query, supplied_data=dataset)
-#     results = cursor.get_next_page()
+    query = datamart.DatamartQuery(
+        keywords = list(keywords_list),
+        variables = []
+    )
+    cursor = client.search_with_data(query, supplied_data=dataset)
+    results = cursor.get_next_page()
 
-#     print(f'keywords:\n\n {keywords_list}', file=sys.__stdout__)
-#     _print_results(results)
+    print(f'keywords:\n\n {keywords_list}', file=sys.__stdout__)
+    _print_results(results)
 
-#     # sometimes joins 500 with no explanation - we will try joins until one works
-#     for result in results:
-#         error = False
-#         try:
-#             join = result.augment(supplied_data=dataset, connection_url=URL)
-#         except Exception as e:
-#             join_with = result.get_json_metadata()['metadata']['name']
-#             join_col = result.get_json_metadata()['augmentation']['right_columns_names']
-#             logger.warn(f'Datamart failed to augment using dataset {join_with} column {join_col} - trying next result')
-#             logger.exception(e)
-#             error = True
-#         if not error:
-#             _, joined_df = base_utils.get_tabular_resource(join, None)
-#             joined_shape = joined_df.shape
-#             return result, joined_shape[1], joined_shape[0]
-#     return (None, 0, 0)
+    # sometimes joins 500 with no explanation - we will try joins until one works
+    for result in results:
+        error = False
+        try:
+            join = result.augment(supplied_data=dataset, connection_url=URL)
+        except Exception as e:
+            join_with = result.get_json_metadata()['metadata']['name']
+            join_col = result.get_json_metadata()['augmentation']['right_columns_names']
+            logger.warn(f'Datamart failed to augment using dataset {join_with} column {join_col} - trying next result')
+            logger.exception(e)
+            error = True
+        if not error:
+            _, joined_df = base_utils.get_tabular_resource(join, None)
+            joined_shape = joined_df.shape
+            return result, joined_shape[1], joined_shape[0]
+    return (None, 0, 0)
 
-# def _print_results(results):
-#     if not results:
-#         return
-#     for result in results:
-#         print(result.score(), file=sys.__stdout__)
-#         print(result.get_json_metadata()['metadata']['name'], file=sys.__stdout__)
-#         if (result.get_augment_hint()):
-#             print("Left Columns: %s" %
-#                   str(result.get_json_metadata()['augmentation']['left_columns_names']), file=sys.__stdout__)
-#             print("Right Columns: %s" %
-#                   str(result.get_json_metadata()['augmentation']['right_columns_names']), file=sys.__stdout__)
-#         else:
-#             print(result.id(), file=sys.__stdout__)
-#         print("-------------------", file=sys.__stdout__)
+def _print_results(results):
+    if not results:
+        return
+    for result in results:
+        print(result.score(), file=sys.__stdout__)
+        print(result.get_json_metadata()['metadata']['name'], file=sys.__stdout__)
+        if (result.get_augment_hint()):
+            print("Left Columns: %s" %
+                  str(result.get_json_metadata()['augmentation']['left_columns_names']), file=sys.__stdout__)
+            print("Right Columns: %s" %
+                  str(result.get_json_metadata()['augmentation']['right_columns_names']), file=sys.__stdout__)
+        else:
+            print(result.id(), file=sys.__stdout__)
+        print("-------------------", file=sys.__stdout__)

--- a/processing/pipelines/link_prediction.py
+++ b/processing/pipelines/link_prediction.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -15,25 +15,21 @@ from distil.primitives.link_prediction import DistilLinkPredictionPrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
-
-
-def create_pipeline(metric: str) -> Pipeline:
+def create_pipeline(metric: str, resolver: Optional[Resolver] = None) -> Pipeline:
 
     # create the basic pipeline
-    vertex_nomination_pipeline = Pipeline(context=PipelineContext.TESTING)
+    vertex_nomination_pipeline = Pipeline()
     vertex_nomination_pipeline.add_input(name='inputs')
 
     # step 0 - extract the graphs
-    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_target')
     vertex_nomination_pipeline.add_step(step)
 
     # step 1 - predict links
-    step = PrimitiveStep(primitive_description=DistilLinkPredictionPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilLinkPredictionPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_target')
     step.add_hyperparameter('metric', ArgumentType.VALUE, metric)

--- a/processing/pipelines/object_detection.py
+++ b/processing/pipelines/object_detection.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set,Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -23,19 +23,18 @@ from dsbox.datapreprocessing.featurizer.image.object_detection import Yolo
 from distil.primitives.ensemble_forest import EnsembleForestPrimitive
 from distil.primitives.image_transfer import ImageTransferPrimitive
 
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
 def create_pipeline(metric: str,
                     cat_mode: str = 'one_hot',
                     max_one_hot: int = 16,
-                    scale: bool = False) -> Pipeline:
+                    scale: bool = False,
+                    resolver: Optional[Resolver] = None) -> Pipeline:
 
     # create the basic pipeline
-    objdetect_pipeline = Pipeline(context=PipelineContext.TESTING)
+    objdetect_pipeline = Pipeline()
     objdetect_pipeline.add_input(name='inputs')
 
     # step 0 - denormalize dataframe (N.B.: injects semantic type information)
-    step = PrimitiveStep(primitive_description=DenormalizePrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DenormalizePrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_hyperparameter('starting_resource', ArgumentType.VALUE, None)
@@ -45,13 +44,13 @@ def create_pipeline(metric: str,
     objdetect_pipeline.add_step(step)
 
     # step 1 - extract dataframe from dataset
-    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_output('produce')
     objdetect_pipeline.add_step(step)
 
     # step 2 - extract files
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
     step.add_output('produce')
     target_types = ('https://metadata.datadrivendiscovery.org/types/PrimaryMultiKey', 'https://metadata.datadrivendiscovery.org/types/FileName')
@@ -59,7 +58,7 @@ def create_pipeline(metric: str,
     objdetect_pipeline.add_step(step)
 
     # step 3 - extract targets
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
     step.add_output('produce')
     target_types = ('https://metadata.datadrivendiscovery.org/types/TrueTarget',)
@@ -67,7 +66,7 @@ def create_pipeline(metric: str,
     objdetect_pipeline.add_step(step)
 
     # step 4 - extract objects
-    step = PrimitiveStep(primitive_description=Yolo.metadata.query())
+    step = PrimitiveStep(primitive_description=Yolo.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
     step.add_output('produce')

--- a/processing/pipelines/semisupervised_tabular.py
+++ b/processing/pipelines/semisupervised_tabular.py
@@ -1,68 +1,69 @@
 from d3m import index
 from d3m.metadata.base import ArgumentType, Context
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
+from typing import Optional
 import sys
 
-def create_pipeline(metric: str) -> Pipeline:
+def create_pipeline(metric: str, resolver: Optional[Resolver] = None) -> Pipeline:
     # Creating pipeline
     pipeline_description = Pipeline()
     pipeline_description.add_input(name='inputs')
 
     # Step 0: Denormalize primitive
-    step_0 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.denormalize.Common'))
+    step_0 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.denormalize.Common'), resolver=resolver)
     step_0.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step_0.add_output('produce')
     pipeline_description.add_step(step_0)
 
     # Step 1, 2 column parser
-    step_1 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.column_parser.DataFrameCommon'))
+    step_1 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.column_parser.DataFrameCommon'), resolver=resolver)
     pipeline_description.add_step(step_1)
 
-    step_2 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.operator.dataset_map.DataFrameCommon'))
+    step_2 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.operator.dataset_map.DataFrameCommon'), resolver=resolver)
     step_2.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step_2.add_hyperparameter(name='primitive', argument_type= ArgumentType.PRIMITIVE, data=1)
     step_2.add_output('produce')
     pipeline_description.add_step(step_2)
 
     # Step 3,4: imputer
-    step_3 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_cleaning.imputer.SKlearn'))
+    step_3 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_cleaning.imputer.SKlearn'), resolver=resolver)
     step_3.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE,data='replace')
     step_3.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE,data=True)
     pipeline_description.add_step(step_3)
 
-    step_4 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.operator.dataset_map.DataFrameCommon'))
+    step_4 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.operator.dataset_map.DataFrameCommon'), resolver=resolver)
     step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
     step_4.add_hyperparameter(name='primitive', argument_type= ArgumentType.PRIMITIVE, data=3)
     step_4.add_output('produce')
     pipeline_description.add_step(step_4)
 
     # Step 5: DISTIL/NK Storc primitive
-    step_5 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.clustering.hdbscan.Hdbscan'))
+    step_5 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.clustering.hdbscan.Hdbscan'), resolver=resolver)
     step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
     step_5.add_hyperparameter(name='long_format', argument_type= ArgumentType.VALUE, data=True)
     step_5.add_output('produce')
     pipeline_description.add_step(step_5)
 
     # Step 6,7,8: Distil ensemble classifier
-    step_6 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon'))
+    step_6 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon'), resolver=resolver)
     step_6.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
     step_6.add_output('produce')
     pipeline_description.add_step(step_6)
 
-    step_7 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon'))
+    step_7 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon'), resolver=resolver)
     step_7.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
     step_7.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE,data=('https://metadata.datadrivendiscovery.org/types/Target',))
     step_7.add_output('produce')
     pipeline_description.add_step(step_7)
 
-    step_8 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.learner.random_forest.DistilEnsembleForest'))
+    step_8 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.learner.random_forest.DistilEnsembleForest'), resolver=resolver)
     step_8.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.6.produce')
     step_8.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.7.produce')
     step_8.add_output('produce')
     pipeline_description.add_step(step_8)
 
     # Step 9, 10: construct output
-    step_9 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.construct_predictions.DataFrameCommon'))
+    step_9 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.construct_predictions.DataFrameCommon'), resolver=resolver)
     step_9.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.8.produce')
     step_9.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
     step_9.add_output('produce')

--- a/processing/pipelines/tabular.py
+++ b/processing/pipelines/tabular.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -26,33 +26,32 @@ from sklearn_wrap import SKMissingIndicator
 from sklearn_wrap import SKImputer
 from sklearn_wrap import SKStandardScaler
 
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
 # CDB: Totally unoptimized.  Pipeline creation code could be simplified but has been left
 # in a naively implemented state for readability for now.
 def create_pipeline(metric: str,
                     cat_mode: str = 'one_hot',
                     max_one_hot: int = 16,
                     scale: bool = False,
-                    include_one_hot = True) -> Pipeline:
+                    include_one_hot = True,
+                    resolver: Optional[Resolver] = None) -> Pipeline:
     input_val = 'steps.{}.produce'
 
     if not include_one_hot:
         max_one_hot = 0
 
     # create the basic pipeline
-    tabular_pipeline = Pipeline(context=PipelineContext.TESTING)
+    tabular_pipeline = Pipeline()
     tabular_pipeline.add_input(name='inputs')
 
     # extract dataframe from dataset
-    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     tabular_pipeline.add_step(step)
     previous_step = 0
 
     # Parse columns.
-    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_output('produce')
     semantic_types = ('http://schema.org/Integer', 'http://schema.org/Float',
@@ -64,7 +63,7 @@ def create_pipeline(metric: str,
 
 
     # Extract attributes
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
     step.add_output('produce')
     step.add_hyperparameter('semantic_types', ArgumentType.VALUE, ('https://metadata.datadrivendiscovery.org/types/Attribute',))
@@ -73,7 +72,7 @@ def create_pipeline(metric: str,
     attributes_step = previous_step
 
     # Extract targets
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
     step.add_output('produce')
     target_types = ('https://metadata.datadrivendiscovery.org/types/Target', 'https://metadata.datadrivendiscovery.org/types/TrueTarget')
@@ -83,35 +82,35 @@ def create_pipeline(metric: str,
     target_step = previous_step
 
     # Append date enricher.  Looks for date columns and normalizes them.
-    step = PrimitiveStep(primitive_description=EnrichDatesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=EnrichDatesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(attributes_step))
     step.add_output('produce')
     tabular_pipeline.add_step(step)
     previous_step += 1
 
     # append list encoder. Take list and expand them across columns
-    step = PrimitiveStep(primitive_description=ListEncoderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ListEncoderPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(attributes_step))
     step.add_output('produce')
     tabular_pipeline.add_step(step)
     previous_step += 1
 
     # Append singleton replacer.  Looks for categorical values that only occur once in a column and replace them with a flag.
-    step = PrimitiveStep(primitive_description=ReplaceSingletonsPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ReplaceSingletonsPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_output('produce')
     tabular_pipeline.add_step(step)
     previous_step += 1
 
     # Append categorical imputer.  Finds missing categorical values and replaces them with an imputed value.
-    step = PrimitiveStep(primitive_description=CategoricalImputerPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=CategoricalImputerPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_output('produce')
     tabular_pipeline.add_step(step)
     previous_step += 1
 
     # Adds an svm text encoder for text fields.
-    step = PrimitiveStep(primitive_description=TextEncoderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=TextEncoderPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(target_step))
     step.add_output('produce')
@@ -121,7 +120,7 @@ def create_pipeline(metric: str,
 
     # Adds a one hot encoder for categoricals of low cardinality.
     if cat_mode == 'one_hot' and include_one_hot:
-        step = PrimitiveStep(primitive_description=OneHotEncoderPrimitive.metadata.query())
+        step = PrimitiveStep(primitive_description=OneHotEncoderPrimitive.metadata.query(), resolver=resolver)
         step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
         step.add_output('produce')
         step.add_hyperparameter('max_one_hot', ArgumentType.VALUE, max_one_hot)
@@ -129,7 +128,7 @@ def create_pipeline(metric: str,
         previous_step += 1
 
     # Adds a binary encoder for categoricals of high cardinality.
-    step = PrimitiveStep(primitive_description=BinaryEncoderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=BinaryEncoderPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_output('produce')
     if cat_mode == 'one_hot':
@@ -144,7 +143,7 @@ def create_pipeline(metric: str,
     # missing data present.  This leads to issues when there is missing data in the fit set and not the produce set, as the
     # training features don't match the produce features.
     #
-    # step = PrimitiveStep(primitive_description=SKMissingIndicator.SKMissingIndicator.metadata.query())
+    # step = PrimitiveStep(primitive_description=SKMissingIndicator.SKMissingIndicator.metadata.query(), resolver=resolver)
     # step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     # step.add_output('produce')
     # step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, True)
@@ -156,7 +155,7 @@ def create_pipeline(metric: str,
 
 
     # Adds SK learn simple imputer
-    step = PrimitiveStep(primitive_description=SKImputer.SKImputer.metadata.query())
+    step = PrimitiveStep(primitive_description=SKImputer.SKImputer.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_output('produce')
     step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, True)
@@ -167,7 +166,7 @@ def create_pipeline(metric: str,
 
     # Append scaler for numerical values.
     if scale:
-        step = PrimitiveStep(primitive_description=SKStandardScaler.SKStandardScaler.metadata.query())
+        step = PrimitiveStep(primitive_description=SKStandardScaler.SKStandardScaler.metadata.query(), resolver=resolver)
         step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
         step.add_output('produce')
         step.add_hyperparameter('use_semantic_types', ArgumentType.VALUE, True)
@@ -176,7 +175,7 @@ def create_pipeline(metric: str,
         previous_step += 1
 
     # Generates a random forest ensemble model.
-    step = PrimitiveStep(primitive_description=EnsembleForestPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=EnsembleForestPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(target_step))
     step.add_output('produce')
@@ -185,7 +184,7 @@ def create_pipeline(metric: str,
     previous_step += 1
 
     # # convert predictions to expected format
-    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
     step.add_output('produce')

--- a/processing/pipelines/text.py
+++ b/processing/pipelines/text.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -21,9 +21,6 @@ from common_primitives.extract_columns_semantic_types import ExtractColumnsBySem
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
-
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
 # CDB: Totally unoptimized.  Pipeline creation code could be simplified but has been left
 # in a naively implemented state for readability for now.
 #
@@ -35,27 +32,28 @@ PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1
 def create_pipeline(metric: str,
                     cat_mode: str = 'one_hot',
                     max_one_hot: int = 16,
-                    scale: bool = False) -> Pipeline:
+                    scale: bool = False,
+                    resolver: Optional[Resolver] = None) -> Pipeline:
 
     # create the basic pipeline
-    text_pipeline = Pipeline(context=PipelineContext.TESTING)
+    text_pipeline = Pipeline()
     text_pipeline.add_input(name='inputs')
 
     # step 0 - denormalize dataframe (injects semantic type information)
-    step = PrimitiveStep(primitive_description=DenormalizePrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DenormalizePrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     text_pipeline.add_step(step)
 
     # step 1 - extract dataframe from dataset
-    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_output('produce')
     text_pipeline.add_step(step)
 
 
     # step 2 - read text
-    step = PrimitiveStep(primitive_description=TextReaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=TextReaderPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
     step.add_output('produce')
     step.add_hyperparameter('use_columns', ArgumentType.VALUE,[0,1])
@@ -64,7 +62,7 @@ def create_pipeline(metric: str,
 
 
     # step 3 - Parse columns.
-    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.2.produce')
     step.add_output('produce')
     semantic_types = ('http://schema.org/Boolean', 'http://schema.org/Integer', 'http://schema.org/Float',
@@ -74,24 +72,24 @@ def create_pipeline(metric: str,
 
 
     # step 4 - Extract attributes
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
     step.add_output('produce')
     step.add_hyperparameter('semantic_types', ArgumentType.VALUE, ('https://metadata.datadrivendiscovery.org/types/Attribute',))
     text_pipeline.add_step(step)
-    
+
 
     # step 5 - Extract targets
-    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
     step.add_output('produce')
     target_types = ('https://metadata.datadrivendiscovery.org/types/Target', 'https://metadata.datadrivendiscovery.org/types/TrueTarget')
     step.add_hyperparameter('semantic_types', ArgumentType.VALUE, target_types)
     text_pipeline.add_step(step)
-    
+
 
     # step 6 - generates a text classification model.
-    step = PrimitiveStep(primitive_description=TextClassifierPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=TextClassifierPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.5.produce')
     step.add_output('produce')
@@ -101,7 +99,7 @@ def create_pipeline(metric: str,
 
 
     # step 7 - convert predictions to expected format
-    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ConstructPredictionsPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.6.produce')
     step.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
     step.add_output('produce')

--- a/processing/pipelines/timeseries_lstm_fcn.py
+++ b/processing/pipelines/timeseries_lstm_fcn.py
@@ -1,29 +1,30 @@
 import logging
 import numpy as np
 import pandas as pd
+from typing import Optional
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
 from d3m.primitives.time_series_classification.convolutional_neural_net import LSTM_FCN
 from distil.primitives.timeseries_formatter import TimeSeriesFormatterPrimitive
 
-def create_pipeline(metric: str) -> Pipeline:
+def create_pipeline(metric: str, resolver: Optional[Resolver] = None) -> Pipeline:
 
     # create the basic pipeline
     lstm_fcn_pipeline = Pipeline()
     lstm_fcn_pipeline.add_input(name='inputs')
 
     # step 0 - flatten the timeseries if necessary
-    step = PrimitiveStep(primitive_description=TimeSeriesFormatterPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=TimeSeriesFormatterPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     lstm_fcn_pipeline.add_step(step)
 
     # step 1 - LSTM FCN classification
-    step = PrimitiveStep(primitive_description=LSTM_FCN.metadata.query()) 
+    step = PrimitiveStep(primitive_description=LSTM_FCN.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_hyperparameter(name='attention_lstm', argument_type= ArgumentType.VALUE, data=False)

--- a/processing/pipelines/timeseries_var.py
+++ b/processing/pipelines/timeseries_var.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -15,25 +15,22 @@ from common_primitives.construct_predictions import ConstructPredictionsPrimitiv
 from common_primitives.column_parser import ColumnParserPrimitive
 
 
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
-
-def create_pipeline(metric: str) -> Pipeline:
+def create_pipeline(metric: str, resolver: Optional[Resolver] = None) -> Pipeline:
     previous_step = 0
     input_val = 'steps.{}.produce'
 
     # create the basic pipeline
-    var_pipeline = Pipeline(context=PipelineContext.TESTING)
+    var_pipeline = Pipeline()
     var_pipeline.add_input(name='inputs')
 
     # step 0 - Extract dataframe from dataset
-    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DatasetToDataFramePrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     var_pipeline.add_step(step)
 
     # step 1 - Parse columns.
-    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=ColumnParserPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
     step.add_output('produce')
     semantic_types = ('http://schema.org/Boolean', 'http://schema.org/Integer', 'http://schema.org/Float',
@@ -44,7 +41,7 @@ def create_pipeline(metric: str) -> Pipeline:
     parse_step = previous_step
 
     # step 2 - Vector Auto Regression
-    step = PrimitiveStep(primitive_description=VAR.metadata.query())
+    step = PrimitiveStep(primitive_description=VAR.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
     step.add_output('produce')

--- a/processing/pipelines/vertex_classification.py
+++ b/processing/pipelines/vertex_classification.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -15,24 +15,20 @@ from sri.psl.vertex_classification import VertexClassification
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
-
-def create_pipeline(metric: str) -> Pipeline:
+def create_pipeline(metric: str, resolver: Optional[Resolver] = None) -> Pipeline:
 
     # create the basic pipeline
-    vertex_classification_pipeline = Pipeline(context=PipelineContext.TESTING)
+    vertex_classification_pipeline = Pipeline()
     vertex_classification_pipeline.add_input(name='inputs')
 
     # step 0 - extract the graphs
-    step = PrimitiveStep(primitive_description=VertexClassificationParser.metadata.query())
+    step = PrimitiveStep(primitive_description=VertexClassificationParser.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     vertex_classification_pipeline.add_step(step)
 
     # step 1 - classify
-    step = PrimitiveStep(primitive_description=VertexClassification.metadata.query())
+    step = PrimitiveStep(primitive_description=VertexClassification.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_hyperparameter('jvm_memory', ArgumentType.VALUE, 0.6)
     step.add_output('produce')

--- a/processing/pipelines/vertex_nomination.py
+++ b/processing/pipelines/vertex_nomination.py
@@ -1,11 +1,11 @@
 import sys
-from typing import List, Dict, Any, Tuple, Set
+from typing import List, Dict, Any, Tuple, Set, Optional
 import logging
 import numpy as np
 import pandas as pd
 
 from d3m import container, utils
-from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep, Resolver
 from d3m.metadata.base import ArgumentType
 from d3m.metadata import hyperparams
 
@@ -15,25 +15,21 @@ from distil.primitives.vertex_nomination import DistilVertexNominationPrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 
-PipelineContext = utils.Enum(value='PipelineContext', names=['TESTING'], start=1)
-
-
-
-def create_pipeline(metric: str) -> Pipeline:
+def create_pipeline(metric: str, resolver: Optional[Resolver] = None) -> Pipeline:
 
     # create the basic pipeline
-    vertex_nomination_pipeline = Pipeline(context=PipelineContext.TESTING)
+    vertex_nomination_pipeline = Pipeline()
     vertex_nomination_pipeline.add_input(name='inputs')
 
     # step 0 - extract the graphs
-    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilSingleGraphLoaderPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
     step.add_output('produce')
     step.add_output('produce_target')
     vertex_nomination_pipeline.add_step(step)
 
     # step 1 - nominate
-    step = PrimitiveStep(primitive_description=DistilVertexNominationPrimitive.metadata.query())
+    step = PrimitiveStep(primitive_description=DistilVertexNominationPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
     step.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce_target')
     step.add_hyperparameter('metric', ArgumentType.VALUE, metric)

--- a/server/task_manager.py
+++ b/server/task_manager.py
@@ -51,7 +51,7 @@ class TaskManager():
         # serialize the pipeline to a string for storage in db if one is provided
         search_template: str = None
         if message.HasField('template'):
-            search_template_obj = api_utils.decode_pipeline_description(message.template, pipeline.Resolver())
+            search_template_obj = api_utils.decode_pipeline_description(message.template, pipeline.Resolver(load_all_primitives=False))
             search_template = search_template_obj.to_json()
 
         # Create search row in DB


### PR DESCRIPTION
Adds a new resolver that will lazy load primitives, saving about 30 seconds of startup time, while also removing an enormous amount of error spew on init.  This change was motivated by the fact that we made a copy/paste error and ended up re-using an existing primitive UUID when creating the TimeSeriesFormatter.  Lazy loading loads via the primitive's Python path and not UUID, so the clash is avoided.

The reason this is currently WiP is that it requires re-testing all of the pipelines.  I've run tabular and timeseries VAR through our TA3, but none of the others yet.  The changes are similar in every case, but due to Python's lack of static types, we can only verify by re-running everything.  If you're okay with dealing with any issues that crop up while testing for the dry run submission it can be merged.  Otherwise, I can test more of the pipelines myself.