### PR TITLE
Use produce request ID for results filename

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ def produce_task(logger, session, task):
         output_keys = json.loads(task.output_keys)
         for output_key in output_keys:
             if output_key in results.values:
-                preds_path = utils.make_preds_filename(task.fit_solution_id, output_key=output_key)
+                preds_path = utils.make_preds_filename(task.request_id, output_key=output_key)
                 results.values[output_key].to_csv(preds_path, index=False)
         session.commit()
     except Exception as e:

--- a/server/task_manager.py
+++ b/server/task_manager.py
@@ -370,7 +370,7 @@ class TaskManager():
                 for task_key in task_keys:
                     # generate a uri from the key and make sure the file exists
                     # TODO(jtorrez): predictions filename creation should live somewhere better than utils
-                    preds_path = utils.make_preds_filename(task.fit_solution_id, output_key=task_key)
+                    preds_path = utils.make_preds_filename(task.request_id, output_key=task_key)
                     if not preds_path.exists() and not preds_path.is_file():
                         raise FileNotFoundError("Predictions file {} doesn't exist".format(preds_path))
 


### PR DESCRIPTION
Uses the produce request ID as the result filename on produce calls.  Previously used fitted solution ID, which would causes multiple produce calls to overwrite results.