### PR TITLE
Scoring fixes

### DIFF
--- a/processing/pipelines/remote_sensing.py
+++ b/processing/pipelines/remote_sensing.py
@@ -18,7 +18,6 @@ from common_primitives.simple_profiler import SimpleProfilerPrimitive
 
 
 from distil.primitives.satellite_image_loader import DataFrameSatelliteImageLoaderPrimitive
-from distil.primitives.prediction_expansion import PredictionExpansionPrimitive
 from distil.primitives.ensemble_forest import EnsembleForestPrimitive
 from distil.primitives.image_transfer import ImageTransferPrimitive
 from d3m.primitives.data_preprocessing.dataset_sample import Common as DatasetSamplePrimitive

--- a/processing/pipelines/remote_sensing.py
+++ b/processing/pipelines/remote_sensing.py
@@ -101,7 +101,6 @@ def create_pipeline(metric: str,
     previous_step += 1
     input_step = previous_step
 
-
     # step 5 - extract targets
     step = PrimitiveStep(primitive_description=ExtractColumnsBySemanticTypesPrimitive.metadata.query(), resolver=resolver)
     step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(parse_step))
@@ -130,15 +129,6 @@ def create_pipeline(metric: str,
     step.add_hyperparameter('use_columns', ArgumentType.VALUE, [0, 1])
     image_pipeline.add_step(step)
     previous_step += 1
-
-    step = PrimitiveStep(primitive_description=PredictionExpansionPrimitive.metadata.query(), resolver=resolver)
-    step.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(previous_step))
-    step.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference=input_val.format(image_step-1))
-    step.add_output('produce')
-    step.add_hyperparameter('use_columns', ArgumentType.VALUE, [0, 1])
-    image_pipeline.add_step(step)
-    previous_step += 1
-
 
     # Adding output step to the pipeline
     image_pipeline.add_output(name='output', data_reference=input_val.format(previous_step))

--- a/processing/pipelines/tabular.py
+++ b/processing/pipelines/tabular.py
@@ -235,7 +235,7 @@ def create_pipeline(metric: str,
     step.add_output('produce')
     if not use_boost:
         step.add_hyperparameter('metric', ArgumentType.VALUE, metric)
-    step.add_hyperparameter('grid_search', ArgumentType.VALUE, grid_search)
+        step.add_hyperparameter('grid_search', ArgumentType.VALUE, grid_search)
     tabular_pipeline.add_step(step)
     previous_step += 1
 

--- a/processing/scoring.py
+++ b/processing/scoring.py
@@ -170,9 +170,9 @@ class Scorer:
             self.logger.warning("Pipleine produced > 1 outputs. Scoring first output only.")
         result_df = results.values['outputs.0']
         # d3m predictions format columns are [d3mIndex, prediction, weight (optional)]
-        result_series = result_df.iloc[:, 1]
         result_df = result_df.set_index(result_df['d3mIndex'])
         result_df.index = result_df.index.map(int)
+        result_df.sort_index(inplace=True)
 
         # put the ground truth predictions into a single col dataframe with the d3mIndex
         # as the index
@@ -180,6 +180,7 @@ class Scorer:
         true_df = true_df.set_index(pd.to_numeric(true_df['d3mIndex']))
         # make sure the result and truth have the same d3mIndex
         true_df = true_df.loc[result_df.index.unique()]
+        true_df.sort_index(inplace=True)
 
         true_series = true_df.iloc[:, self.target_idx]
         true_series = true_series.astype(result_series.dtype)

--- a/processing/scoring.py
+++ b/processing/scoring.py
@@ -169,22 +169,26 @@ class Scorer:
         if len(results.values) > 1:
             self.logger.warning("Pipleine produced > 1 outputs. Scoring first output only.")
         result_df = results.values['outputs.0']
-        # d3m predictions format columns are [d3mIndex, prediction, weight (optional)]
-        result_df = result_df.set_index(result_df['d3mIndex'])
-        result_df.index = result_df.index.map(int)
-        result_df.sort_index(inplace=True)
 
-        # put the ground truth predictions into a single col dataframe with the d3mIndex
-        # as the index
+        # d3m predictions format columns are [d3mIndex, prediction, weight (optional)] - get the predictions
+        # into index sorted order
+        result_df.sort_values(by=['d3mIndex'], inplace=True)
+        result_series = result_df.iloc[:, 1]
+
+        # put the ground truth into a single col dataframe with the d3mIndex
+        # as the index - it won't be typed so we forst it to the type used in the
+        # predictions
         true_df = self.inputs['learningData']
-        true_df = true_df.set_index(pd.to_numeric(true_df['d3mIndex']))
-        # make sure the result and truth have the same d3mIndex
-        true_df = true_df.loc[result_df.index.unique()]
-        true_df.sort_index(inplace=True)
+        true_df = true_df.astype({'d3mIndex': result_df['d3mIndex'].dtype})
 
+        # in case its a multindex, we'll only take one row for each unique index,
+        # and sort to make sure its in the same order as teh result series
+        true_df.drop_duplicates(inplace=True, subset='d3mIndex')
+        true_df.sort_values(by=['d3mIndex'], inplace=True)
         true_series = true_df.iloc[:, self.target_idx]
+        # force the truth value to the same type as the predicted value
         true_series = true_series.astype(result_series.dtype)
-
+        # compute the score
         score = self._score(self.metric, true_series, result_series)
 
         return [score]


### PR DESCRIPTION
Scoring with multi-index results wasn't properly preserving ordering.  The code has been reworked a bit to ensure that order is properly preserved.  For now, we've also removed the requirement to expand the predictions, as we are handling multi-index in scoring itself.