### PR TITLE
Handle per-label confidence scores in returned results

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export HYPERPARAMETER_TUNING=False
-export COMPUTE_CONFIDENCES=False
+export COMPUTE_CONFIDENCES=True
 export REMOTE_SENSING_BATCH_SIZE=32
 export TIME_LIMIT=20
 export DEBUG=True


### PR DESCRIPTION
Fixes #230

- Properly handles per-label confidence scores included in results
- Enables confidence computation by default
