### PR TITLE
MLP pipeline integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ sherpa_temp
 *.pkl
 deepar_weights
 distil-auto-ml.log
+model_weights.pth

--- a/config.py
+++ b/config.py
@@ -45,3 +45,6 @@ HYPERPARAMETER_TUNING = os.getenv("HYPERPARAMETER_TUNING", "True") == "True"
 
 # controls parallelism within primitives - defaults to the number of CPUs
 N_JOBS = int(os.getenv("N_JOBS", -1))
+
+# enable use of mlp classifier + gradcam visualization
+MLP_CLASSIFIER = os.getenv("MLP_CLASSIFIER", "True") == "True"

--- a/main.py
+++ b/main.py
@@ -123,12 +123,13 @@ def score_task(logger, session, server, task):
             fitted_runtime = server.get_fitted_runtime(task.solution_id)
 
         scorer = Scorer(logger, task, score_config, fitted_runtime, target_idx)
-        score_values = scorer.run()
+        score_values, metric_used = scorer.run()
         for score_value in score_values:
             score = models.Scores(
                 solution_id=task.solution_id,
                 score_config_id=score_config.id,
                 value=score_value,
+                metric_used=metric_used,
             )
             session.add(score)
             session.commit()

--- a/models.py
+++ b/models.py
@@ -165,6 +165,8 @@ class Scores(Base):
     solution_id = Column(String, ForeignKey("solutions.id"))
     fit_solution_id = Column(String, ForeignKey("fit_solution.id"))
     score_config_id = Column(Integer, ForeignKey("score_config.id"))
+    # metric that was actually applied - can differ from  requested
+    metric_used = Column(String)
     value = Column(Float)
 
 

--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -261,16 +261,17 @@ def create(
             )
         )
     elif pipeline_type == "remote_sensing":
-        pipelines.append(
-            remote_sensing_mlp.create_pipeline(
-                metric=metric,
-                resolver=resolver,
-                batch_size=config.REMOTE_SENSING_BATCH_SIZE,
-                n_jobs=n_jobs,
-                **pipeline_info,
+        if config.MLP_CLASSIFIER:
+            pipelines.append(
+                remote_sensing_mlp.create_pipeline(
+                    metric=metric,
+                    resolver=resolver,
+                    batch_size=config.REMOTE_SENSING_BATCH_SIZE,
+                    n_jobs=n_jobs,
+                    **pipeline_info,
+                )
             )
-        )
-        if max_models > 1:
+        else:
             pipelines.append(
                 remote_sensing.create_pipeline(
                     metric=metric,

--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -262,29 +262,6 @@ def create(
         )
     elif pipeline_type == "remote_sensing":
         pipelines.append(
-            remote_sensing.create_pipeline(
-                metric=metric,
-                resolver=resolver,
-                grid_search=True,
-                n_jobs=n_jobs,
-                svc=True,
-                batch_size=config.REMOTE_SENSING_BATCH_SIZE,
-                **pipeline_info,
-            )
-        )
-        if max_models > 1:
-            pipelines.append(
-                remote_sensing.create_pipeline(
-                    metric=metric,
-                    resolver=resolver,
-                    grid_search=True,
-                    n_jobs=n_jobs,
-                    batch_size=config.REMOTE_SENSING_BATCH_SIZE,
-                    **pipeline_info,
-                )
-            )
-    elif pipeline_type == "remote_sensing_mlp":
-        pipelines.append(
             remote_sensing_mlp.create_pipeline(
                 metric=metric,
                 resolver=resolver,
@@ -293,6 +270,17 @@ def create(
                 **pipeline_info,
             )
         )
+        if max_models > 1:
+            pipelines.append(
+                remote_sensing.create_pipeline(
+                    metric=metric,
+                    resolver=resolver,
+                    n_jobs=n_jobs,
+                    svc=True,
+                    batch_size=config.REMOTE_SENSING_BATCH_SIZE,
+                    **pipeline_info,
+                )
+            )
     elif pipeline_type == "remote_sensing_pretrained":
         pipelines.append(
             remote_sensing_pretrained.create_pipeline(

--- a/processing/pipelines/remote_sensing.py
+++ b/processing/pipelines/remote_sensing.py
@@ -1,5 +1,4 @@
 from typing import Optional
-
 from distil.primitives.column_parser import ColumnParserPrimitive
 from common_primitives.construct_predictions import ConstructPredictionsPrimitive
 from common_primitives.dataset_to_dataframe import DatasetToDataFramePrimitive
@@ -192,6 +191,7 @@ def create_pipeline(
             data_reference=input_val.format(target_step),
         )
         step.add_output("produce")
+        step.add_hyperparameter("scaling", ArgumentType.VALUE, "unit_norm")
     else:
         # use random forest
         step = PrimitiveStep(

--- a/processing/pipelines/remote_sensing_mlp.py
+++ b/processing/pipelines/remote_sensing_mlp.py
@@ -20,6 +20,8 @@ from distil.primitives.label_encoder import SKLabelEncoder
 from distil.primitives.satellite_image_loader import (
     DataFrameSatelliteImageLoaderPrimitive,
 )
+import config
+import os
 
 # Overall implementation relies on passing the entire dataset through the pipeline, with the primitives
 # identifying columns to operate on based on type.  Alternative implementation (that better lines up with
@@ -186,6 +188,12 @@ def create_pipeline(
         data_reference=input_val.format(target_step),
     )
     step.add_hyperparameter("all_confidences", ArgumentType.VALUE, True)
+    step.add_hyperparameter(
+        "weights_filepath",
+        ArgumentType.VALUE,
+        os.path.join(config.OUTPUT_DIR, "mlp_classifier.pth"),
+    )
+    step.add_hyperparameter("image_dim", ArgumentType.VALUE, 120)
     step.add_output("produce")
     image_pipeline.add_step(step)
     previous_step += 1

--- a/processing/pipelines/remote_sensing_mlp.py
+++ b/processing/pipelines/remote_sensing_mlp.py
@@ -37,7 +37,6 @@ def create_pipeline(
     # create the basic pipeline
     image_pipeline = Pipeline()
     image_pipeline.add_input(name="inputs")
-    tune_steps = []
 
     # step 0 - denormalize dataframe (N.B.: injects semantic type information)
     step = PrimitiveStep(
@@ -154,20 +153,6 @@ def create_pipeline(
     step.add_hyperparameter("semantic_types", ArgumentType.VALUE, target_types)
     image_pipeline.add_step(step)
     previous_step += 1
-
-    # step 6 - encode targets
-    step = PrimitiveStep(
-        primitive_description=SKLabelEncoder.metadata.query(), resolver=resolver
-    )
-    step.add_argument(
-        name="inputs",
-        argument_type=ArgumentType.CONTAINER,
-        data_reference=input_val.format(previous_step),
-    )
-    step.add_output("produce")
-    step.add_hyperparameter("return_result", ArgumentType.VALUE, "replace")
-    image_pipeline.add_step(step)
-    previous_step += 1
     target_step = previous_step
 
     # step 7 - featurize imagery
@@ -200,7 +185,7 @@ def create_pipeline(
         argument_type=ArgumentType.CONTAINER,
         data_reference=input_val.format(target_step),
     )
-    step.add_hyperparameter("all_confidences", ArgumentType.VALUE, False)
+    step.add_hyperparameter("all_confidences", ArgumentType.VALUE, True)
     step.add_output("produce")
     image_pipeline.add_step(step)
     previous_step += 1
@@ -230,4 +215,4 @@ def create_pipeline(
         name="output", data_reference=input_val.format(previous_step)
     )
 
-    return image_pipeline, tune_steps
+    return image_pipeline, []

--- a/processing/pipelines/remote_sensing_pretrained.py
+++ b/processing/pipelines/remote_sensing_pretrained.py
@@ -199,7 +199,7 @@ def create_pipeline(
             argument_type=ArgumentType.CONTAINER,
             data_reference=input_val.format(target_step),
         )
-        step.add_hyperparameter("normalize", ArgumentType.VALUE, False)
+        step.add_hyperparameter("scaling", ArgumentType.VALUE, "unit_norm")
         step.add_hyperparameter("rank_confidences", ArgumentType.VALUE, False)
         step.add_output("produce")
         rs_pretrained_pipeline.add_step(step)

--- a/server/task_manager.py
+++ b/server/task_manager.py
@@ -256,13 +256,8 @@ class TaskManager:
             if scores:
                 score_msgs = []
                 for m in scores:
-                    config = (
-                        self.session.query(models.ScoreConfig)
-                        .filter(models.ScoreConfig.id == m.score_config_id)
-                        .first()
-                    )
                     score_msgs.append(
-                        self.msg.make_score_message(config.metric, m.value)
+                        self.msg.make_score_message(m.metric_used, m.value)
                     )
 
                 progress_msg = self.msg.make_progress_msg("COMPLETED")


### PR DESCRIPTION
fixes #238

1. Adds pipeline for MPL classifier to `remote_sensing_path`
1. Adds new env var `MLP_CLASSIFIER` to toggle between ranked linear SVC and MLP classifier use.  We may want to allow both to run once MLP classifier is more stable.
1. Fixes a number of additional issues around ROC AUC scoring to allow for the system to provide fallback scores instead of outright failing when ROC AUC is requested, but the confidence information is not available/improperly formatted.