### PR TITLE
Return error messages via ta3ta2 API on ta2 failures

### DIFF
--- a/main.py
+++ b/main.py
@@ -342,14 +342,18 @@ def job_loop(logger, session, server):
         )
     except Exception as e:
         logger.warn("Exception getting task: {}".format(e), exc_info=True)
+
     # If there is work to be done...
-    if task:
-        if task.type == "FIT":
-            fit_task(logger, session, server, task)
-        elif task.type == "SCORE":
-            score_task(logger, session, server, task)
-        elif task.type == "PRODUCE":
-            produce_task(logger, session, server, task)
+    try:
+        if task:
+            if task.type == "FIT":
+                fit_task(logger, session, server, task)
+            elif task.type == "SCORE":
+                score_task(logger, session, server, task)
+            elif task.type == "PRODUCE":
+                produce_task(logger, session, server, task)
+    except Exception as e:
+        logger.warn("Exception running task: {}".format(e), exc_info=True)
 
 
 def main(once=False):


### PR DESCRIPTION
fixes #117 

Exceptions that were thrown during TA2 processing of fit, score, produce tasks were caught and flagged as errors, but no errors status messages were ever sent back to the TA3.  Periodic status messages were also not being sent for score and produce tasks.  The search message is currently missing this functionality, but it was implemented differently and seems to be a more involved change.  A follow up issue will be logged for that case.