### PR TITLE
Multiple input datasets

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ def produce_task(logger, session, server, task):
             test_dataset = server.get_loaded_dataset(dataset_uri)
             if test_dataset is None:
                 test_dataset = load_data(dataset_uri)
-            test_datasets.append(train_dataset)
+            test_datasets.append(test_dataset)
         results = ex_pipeline.produce(
             fitted_runtime, test_datasets, outputs_to_expose=output_keys
         )

--- a/main.py
+++ b/main.py
@@ -28,6 +28,9 @@ from server import messages
 pathlib.Path(config.OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
 
 
+def decode_dataset_uri(dataset_uri):
+    return dataset_uri.split(",")
+
 def produce_task(logger, session, server, task):
     try:
         logger.info("Starting produce task ID {}".format(task.id))
@@ -37,11 +40,15 @@ def produce_task(logger, session, server, task):
 
         # call produce on a fitted pipeline
         fitted_runtime = server.get_fitted_runtime(task.fit_solution_id)
-        test_dataset = server.get_loaded_dataset(task.dataset_uri)
-        if test_dataset is None:
-            test_dataset = load_data(task.dataset_uri)
+        dataset_uris = decode_dataset_uri(task.dataset_uri)
+        test_datasets = []
+        for dataset_uri in dataset_uris:
+            test_dataset = server.get_loaded_dataset(dataset_uri)
+            if test_dataset is None:
+                test_dataset = load_data(dataset_uri)
+            test_datasets.append(train_dataset)
         results = ex_pipeline.produce(
-            fitted_runtime, test_dataset, outputs_to_expose=output_keys
+            fitted_runtime, test_datasets, outputs_to_expose=output_keys
         )
 
         # loop over the (ordered) list of requested output types until we find one that we support
@@ -178,13 +185,17 @@ def fit_task(logger, session, server, task):
         # it doesn't need to be serialized.
         run_as_standard = not task.fully_specified
 
-        train_dataset = server.get_loaded_dataset(task.dataset_uri)
-        if train_dataset is None:
-            train_dataset = load_data(task.dataset_uri)
+        dataset_uris = decode_dataset_uri(task.dataset_uri)
+        train_datasets = []
+        for dataset_uri in dataset_uris:
+            train_dataset = server.get_loaded_dataset(dataset_uri)
+            if train_dataset is None:
+                train_dataset = load_data(dataset_uri)
+            train_datasets.append(train_dataset)
         fitted_runtime, result = ex_pipeline.fit(
             pipeline_obj,
             problem_obj,
-            train_dataset,
+            train_datasets,
             is_standard_pipeline=run_as_standard,
             outputs_to_expose=output_keys,
         )
@@ -281,15 +292,19 @@ def search_task(logger, session, server, search):
         )
 
         # based on our problem type and data type, create a pipeline
+        dataset_uris = decode_dataset_uri(search.dataset_uri)
+        dataset_uri = ""
+        if len(dataset_uris) > 0:
+            dataset_uri = dataset_uris[0]
         pipeline_objs, dataset, ranks = ex_pipeline.create(
-            search.dataset_uri,
+            dataset_uri,
             problem_obj,
             search.time_limit,
             search.max_models,
             search_template_obj,
             resolver=resolver,
         )
-        server.add_loaded_dataset(search.dataset_uri, dataset)
+        server.add_loaded_dataset(dataset_uri, dataset)
         for i, pipeline_obj in enumerate(pipeline_objs):
             pipeline_json = pipeline_obj.to_json(nest_subpipelines=True)
 

--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -462,7 +462,7 @@ def create(
 def fit(
     pipeline: pipeline.Pipeline,
     problem: problem.Problem,
-    input_dataset: container.Dataset,
+    input_datasets: typing.Iterable[container.Dataset],
     is_standard_pipeline=True,
     outputs_to_expose: typing.Iterable[str] = None,
 ) -> Tuple[Optional[runtime.Runtime], Optional[runtime.Result]]:
@@ -472,7 +472,7 @@ def fit(
 
     fitted_runtime, _, result = runtime.fit(
         pipeline,
-        [input_dataset],
+        input_datasets,
         problem_description=problem,
         hyperparams=hyperparams,
         random_seed=random_seed,
@@ -491,12 +491,12 @@ def fit(
 
 def produce(
     fitted_pipeline: runtime.Runtime,
-    input_dataset: container.Dataset,
+    input_datasets: typing.Iterable[container.Dataset],
     outputs_to_expose: typing.Iterable[str] = None,
 ) -> runtime.Result:
     _, result = runtime.produce(
         fitted_pipeline,
-        [input_dataset],
+        input_datasets,
         expose_produced_outputs=True,
         outputs_to_expose=outputs_to_expose,
     )

--- a/server/messages.py
+++ b/server/messages.py
@@ -18,7 +18,7 @@ class Messaging:
     def get_dataset_uri(self, msg):
         if len(msg.inputs) == 0:
             return False
-        return msg.inputs[0].dataset_uri or msg.inputs[0].csv_uri
+        return [i.dataset_uri or i.csv_uri for i in msg.inputs]
 
     def get_problem_type(self, msg):
         _type = msg.problem.problem.task_keywords

--- a/server/task_manager.py
+++ b/server/task_manager.py
@@ -37,6 +37,9 @@ class TaskManager:
         _id = utils.generate_id()
         return _id
 
+    def _encode_dataset_uri(self, dataset_uri):
+        return ",".join(dataset_uri)
+
     def SearchSolutions(self, message):
 
         """Get potential pipelines and load into DB."""
@@ -81,7 +84,7 @@ class TaskManager:
             problem=problem_json,
             time_limit=time_limit,
             max_models=max_models,
-            dataset_uri=dataset_uri,
+            dataset_uri=self._encode_dataset_uri(dataset_uri),
             search_template=search_template_json,
         )
 
@@ -209,7 +212,7 @@ class TaskManager:
             request_id=request_id,
             solution_id=solution_id,
             fit_solution_id=fit_solution_id,
-            dataset_uri=dataset_uri,
+            dataset_uri=self._encode_dataset_uri(dataset_uri),
             score_config_id=conf_id,
             problem=search.problem,
             pipeline=pipeline_json,
@@ -354,7 +357,7 @@ class TaskManager:
             request_id=request_id,
             fit_solution_id=fit_solution_id,
             solution_id=solution_id,
-            dataset_uri=dataset_uri,
+            dataset_uri=self._encode_dataset_uri(dataset_uri),
             pipeline=pipeline_json,
             problem=search.problem,
             fully_specified=fully_specified,
@@ -483,7 +486,7 @@ class TaskManager:
             request_id=request_id,
             fit_solution_id=fitted_solution_id,
             solution_id=fit_solution.solution_id,
-            dataset_uri=dataset_uri,
+            dataset_uri=self._encode_dataset_uri(dataset_uri),
             output_keys=output_keys_json,
             output_types=output_types_json,
         )


### PR DESCRIPTION
Fully specified pipelines can have multiple input datasets (ex: image retrieval). The code was only handling a single dataset uri. Changes were made to pass around arrays of uris. They get encoded into a csv when storing to the database for simplicity.

The search request was not updated much because right now we only needed fully specified pipelines updated. The dataset cache was also not updated to handle multiple datasets for short term simplicity.