### PR TITLE
Remote sensing regression

### DIFF
--- a/processing/router.py
+++ b/processing/router.py
@@ -138,12 +138,13 @@ def is_remote_sensing_pretrained(dataset_doc: dict, problem: dict) -> bool:
     classification = (
         _problem.TaskKeyword.CLASSIFICATION in problem["problem"]["task_keywords"]
     )
+    regression = _problem.TaskKeyword.REGRESSION in problem["problem"]["task_keywords"]
     remote_sensing = (
         _problem.TaskKeyword.REMOTE_SENSING in problem["problem"]["task_keywords"]
     )
     return (
         "image" not in get_resource_types(dataset_doc)
-        and classification
+        and (classification or regression)
         and remote_sensing
         and _problem.TaskKeyword.SEMISUPERVISED not in problem["problem"]["task_keywords"]
     )

--- a/processing/router.py
+++ b/processing/router.py
@@ -146,7 +146,8 @@ def is_remote_sensing_pretrained(dataset_doc: dict, problem: dict) -> bool:
         "image" not in get_resource_types(dataset_doc)
         and (classification or regression)
         and remote_sensing
-        and _problem.TaskKeyword.SEMISUPERVISED not in problem["problem"]["task_keywords"]
+        and _problem.TaskKeyword.SEMISUPERVISED
+        not in problem["problem"]["task_keywords"]
     )
 
 
@@ -162,7 +163,8 @@ def is_remote_sensing(dataset_doc: dict, problem: dict) -> bool:
         "image" in get_resource_types(dataset_doc)
         and (classification or regression)
         and remote_sensing
-        and _problem.TaskKeyword.SEMISUPERVISED not in problem["problem"]["task_keywords"]
+        and _problem.TaskKeyword.SEMISUPERVISED
+        not in problem["problem"]["task_keywords"]
     )
 
 
@@ -211,13 +213,23 @@ def is_text(dataset_doc: dict) -> bool:
 
 
 def is_semisupervised_tabular(problem: dict) -> bool:
-    remote_sensing = _problem.TaskKeyword.REMOTE_SENSING in problem["problem"]["task_keywords"]
-    return not remote_sensing and _problem.TaskKeyword.SEMISUPERVISED in problem["problem"]["task_keywords"]
+    remote_sensing = (
+        _problem.TaskKeyword.REMOTE_SENSING in problem["problem"]["task_keywords"]
+    )
+    return (
+        not remote_sensing
+        and _problem.TaskKeyword.SEMISUPERVISED in problem["problem"]["task_keywords"]
+    )
 
 
 def is_semisupervised_remote_sensing_pretrained(problem: dict) -> bool:
-    remote_sensing = _problem.TaskKeyword.REMOTE_SENSING in problem["problem"]["task_keywords"]
-    return remote_sensing and _problem.TaskKeyword.SEMISUPERVISED in problem["problem"]["task_keywords"]
+    remote_sensing = (
+        _problem.TaskKeyword.REMOTE_SENSING in problem["problem"]["task_keywords"]
+    )
+    return (
+        remote_sensing
+        and _problem.TaskKeyword.SEMISUPERVISED in problem["problem"]["task_keywords"]
+    )
 
 
 # --


### PR DESCRIPTION
Part of fix for uncharted-distil/distil#2497

Allows the router to recognize remote sensing regression.  Because the pipeline uses the ensemble forest primitve, the regression works out of the box.  There are likely TA3 changes that need to be made to finish this off.