### PR TITLE
Label re-mapping for roc_auc_scoring

### DIFF
--- a/models.py
+++ b/models.py
@@ -9,7 +9,6 @@ from sqlalchemy import (
     Text,
     Boolean,
     Float,
-    Binary,
 )
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -157,6 +156,7 @@ class ScoreConfig(Base):
     shuffle = Column(Boolean, default=True)
     random_seed = Column(Integer, default=505)
     stratified = Column(Boolean, default=False)
+    pos_label = Column(String, default="")
 
 
 class Scores(Base):

--- a/server/messages.py
+++ b/server/messages.py
@@ -81,6 +81,13 @@ class Messaging:
             if len(m.metric) is not 0
         ]
 
+        pos_labels = [
+            m.pos_label
+            for m in request.performance_metrics
+            if len(m.pos_label) is not 0
+        ]
+
+
         # method required to be defined
         method = request.configuration.method.lower()
         if len(method) == 0:
@@ -103,6 +110,7 @@ class Messaging:
             solution_id,
             dataset_uri,
             metrics,
+            pos_labels,
             method,
             folds,
             train_test_ratio,

--- a/server/task_manager.py
+++ b/server/task_manager.py
@@ -154,6 +154,7 @@ class TaskManager:
             solution_id,
             dataset_uri,
             metrics,
+            pos_labels,
             method,
             folds,
             train_test_ratio,
@@ -191,10 +192,12 @@ class TaskManager:
         if len(metrics) > 1:
             self.logger.warn(f"only support scoring on one metric - using {metrics[0]}")
         metric = metrics[0]
+        pos_label = pos_labels[0] if len(pos_labels) >= 1 else None
         conf_id = self._generate_id()
         conf = models.ScoreConfig(
             id=conf_id,
             metric=metric,
+            pos_label=pos_label,
             method=method,
             num_folds=folds,
             # TODO: train_test_ratio is currently unused by SolutionScorer

--- a/server/validation.py
+++ b/server/validation.py
@@ -98,7 +98,7 @@ class RequestValidator:
     def validate_score_solution_request(self, request):
         r = self.msg.unpack_score_solution_request(request)
         # unpack fields to be validated from request
-        solution_id, _, metrics, method, _, _, _, _, _ = r
+        solution_id, _, metrics, _, method, _, _, _, _, _ = r
 
         if not solution_id:
             raise ValueError("Must pass a solution_id: {}".format(request))


### PR DESCRIPTION
The `roc_auc_scoring` function from sklearn as a different API than other binary scoring functions in that it doesn't allow for a positive label to be specified.  It instead relies on the ordering of the data to determine a positive label, and in our case, this label may not line up with the label the user marked as a positive.  To address this, we apply the logic used by the `roc_auc_score` function to determine if the user specified positive label will match the label the scoring function internally identifies as positive, and remap if necessary.  This fixes issues with the ROC AUC score being the inverse of what was expected with some remote sensing datasets. 